### PR TITLE
Set devices to unavailable when they are offline

### DIFF
--- a/custom_components/frigidaire/climate.py
+++ b/custom_components/frigidaire/climate.py
@@ -44,8 +44,11 @@ async def async_setup_entry(
     )
 
     async_add_entities(
-        [FrigidaireClimate(client, appliance) for appliance in appliances
-         if appliance.appliance_class == frigidaire.ApplianceClass.AIR_CONDITIONER],
+        [
+            FrigidaireClimate(client, appliance)
+            for appliance in appliances
+            if appliance.appliance_class == frigidaire.ApplianceClass.AIR_CONDITIONER
+        ],
         update_before_add=True,
     )
 
@@ -287,5 +290,5 @@ class FrigidaireClimate(ClimateEntity):
                 self._details.for_code(
                     frigidaire.HaclCode.CONNECTIVITY_STATE
                 ).string_value
-                == "connect"
+                == frigidaire.ConnectivityState.CONNECTED
             )

--- a/custom_components/frigidaire/climate.py
+++ b/custom_components/frigidaire/climate.py
@@ -267,8 +267,14 @@ class FrigidaireClimate(ClimateEntity):
         try:
             details = self._client.get_appliance_details(self._appliance)
             self._details = details
-            self._attr_available = True
         except frigidaire.FrigidaireException:
             if self.available:
                 _LOGGER.error("Failed to connect to Frigidaire servers")
             self._attr_available = False
+        else:
+            self._attr_available = (
+                self._details.for_code(
+                    frigidaire.HaclCode.CONNECTIVITY_STATE
+                ).string_value
+                == "connect"
+            )

--- a/custom_components/frigidaire/humidifier.py
+++ b/custom_components/frigidaire/humidifier.py
@@ -230,7 +230,10 @@ class FrigidaireDehumidifier(HumidifierEntity):
             return
 
         # Turn on if not currently on.
-        if self._details.for_code(frigidaire.HaclCode.APPLIANCE_STATE).number_value == 0:
+        if (
+            self._details.for_code(frigidaire.HaclCode.APPLIANCE_STATE).number_value
+            == 0
+        ):
             self.turn_on()
 
         self._client.execute_action(
@@ -251,5 +254,5 @@ class FrigidaireDehumidifier(HumidifierEntity):
                 self._details.for_code(
                     frigidaire.HaclCode.CONNECTIVITY_STATE
                 ).string_value
-                == "connect"
+                == frigidaire.ConnectivityState.CONNECTED
             )

--- a/custom_components/frigidaire/humidifier.py
+++ b/custom_components/frigidaire/humidifier.py
@@ -242,8 +242,14 @@ class FrigidaireDehumidifier(HumidifierEntity):
         try:
             details = self._client.get_appliance_details(self._appliance)
             self._details = details
-            self._attr_available = True
         except frigidaire.FrigidaireException:
             if self.available:
                 _LOGGER.error("Failed to connect to Frigidaire servers")
             self._attr_available = False
+        else:
+            self._attr_available = (
+                self._details.for_code(
+                    frigidaire.HaclCode.CONNECTIVITY_STATE
+                ).string_value
+                == "connect"
+            )

--- a/custom_components/frigidaire/manifest.json
+++ b/custom_components/frigidaire/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/frigidaire",
   "requirements": [
-    "frigidaire==0.13"
+    "frigidaire==0.14"
   ],
   "dependencies": [],
   "codeowners": [


### PR DESCRIPTION
This will set the devices as unavailable in home assistant if the frigidaire cloud cannot connect to them.

Should we make an enum in the frigidaire library for the connectivity states? They are `connect` and `disconnect` in the `string_value` of hacl code 0000.