### PR TITLE
Simple enums

### DIFF
--- a/custom_components/frigidaire/climate.py
+++ b/custom_components/frigidaire/climate.py
@@ -54,23 +54,23 @@ async def async_setup_entry(
 
 
 FRIGIDAIRE_TO_HA_UNIT = {
-    frigidaire.Unit.FAHRENHEIT.value: TEMP_FAHRENHEIT,
-    frigidaire.Unit.CELSIUS.value: TEMP_CELSIUS,
+    frigidaire.Unit.FAHRENHEIT: TEMP_FAHRENHEIT,
+    frigidaire.Unit.CELSIUS: TEMP_CELSIUS,
 }
 
 FRIGIDAIRE_TO_HA_MODE = {
-    frigidaire.Mode.OFF.value: HVAC_MODE_OFF,
-    frigidaire.Mode.COOL.value: HVAC_MODE_COOL,
-    frigidaire.Mode.FAN.value: HVAC_MODE_FAN_ONLY,
-    frigidaire.Mode.ECO.value: HVAC_MODE_AUTO,
+    frigidaire.Mode.OFF: HVAC_MODE_OFF,
+    frigidaire.Mode.COOL: HVAC_MODE_COOL,
+    frigidaire.Mode.FAN: HVAC_MODE_FAN_ONLY,
+    frigidaire.Mode.ECO: HVAC_MODE_AUTO,
 }
 
 FRIGIDAIRE_TO_HA_FAN_SPEED = {
-    frigidaire.FanSpeed.OFF.value: FAN_OFF,  # when the AC is off
-    frigidaire.FanSpeed.AUTO.value: FAN_AUTO,
-    frigidaire.FanSpeed.LOW.value: FAN_LOW,
-    frigidaire.FanSpeed.MEDIUM.value: FAN_MEDIUM,
-    frigidaire.FanSpeed.HIGH.value: FAN_HIGH,
+    frigidaire.FanSpeed.OFF: FAN_OFF,  # when the AC is off
+    frigidaire.FanSpeed.AUTO: FAN_AUTO,
+    frigidaire.FanSpeed.LOW: FAN_LOW,
+    frigidaire.FanSpeed.MEDIUM: FAN_MEDIUM,
+    frigidaire.FanSpeed.HIGH: FAN_HIGH,
 }
 
 HA_TO_FRIGIDAIRE_FAN_MODE = {
@@ -266,7 +266,7 @@ class FrigidaireClimate(ClimateEntity):
             return
 
         # Turn on if not currently on.
-        if self._details.for_code(frigidaire.HaclCode.AC_MODE).number_value == 0:
+        if self._details.for_code(frigidaire.HaclCode.AC_MODE) == 0:
             self._client.execute_action(
                 self._appliance, frigidaire.Action.set_power(frigidaire.Power.ON)
             )
@@ -287,8 +287,6 @@ class FrigidaireClimate(ClimateEntity):
             self._attr_available = False
         else:
             self._attr_available = (
-                self._details.for_code(
-                    frigidaire.HaclCode.CONNECTIVITY_STATE
-                ).string_value
-                != frigidaire.ConnectivityState.DISCONNECTED.value
+                self._details.for_code(frigidaire.HaclCode.CONNECTIVITY_STATE)
+                != frigidaire.ConnectivityState.DISCONNECTED
             )

--- a/custom_components/frigidaire/humidifier.py
+++ b/custom_components/frigidaire/humidifier.py
@@ -59,24 +59,18 @@ async def async_setup_entry(
 
 
 FRIGIDAIRE_TO_HA_MODE = {
-    frigidaire.Mode.DRY.value: MODE_NORMAL,
-    frigidaire.Mode.CONTINUOUS.value: MODE_BOOST,
+    frigidaire.Mode.DRY: MODE_NORMAL,
+    frigidaire.Mode.CONTINUOUS: MODE_BOOST,
 }
 
-HA_TO_FRIGIDAIRE_MODE = {
-    MODE_NORMAL: frigidaire.Mode.DRY,
-    MODE_BOOST: frigidaire.Mode.CONTINUOUS,
-}
+HA_TO_FRIGIDAIRE_MODE = {v: k for k, v in FRIGIDAIRE_TO_HA_MODE.items()}
 
 FRIGIDAIRE_TO_HA_FAN_MODE = {
-    frigidaire.FanSpeed.LOW.value: FAN_LOW,
-    frigidaire.FanSpeed.HIGH.value: FAN_HIGH,
+    frigidaire.FanSpeed.LOW: FAN_LOW,
+    frigidaire.FanSpeed.HIGH: FAN_HIGH,
 }
 
-HA_TO_FRIGIDAIRE_FAN_MODE = {
-    FAN_LOW: frigidaire.FanSpeed.LOW,
-    FAN_HIGH: frigidaire.FanSpeed.HIGH,
-}
+HA_TO_FRIGIDAIRE_FAN_MODE = {v: k for k, v in FRIGIDAIRE_TO_HA_FAN_MODE.items()}
 
 
 class FrigidaireDehumidifier(HumidifierEntity):
@@ -134,10 +128,7 @@ class FrigidaireDehumidifier(HumidifierEntity):
 
     @property
     def is_on(self):
-        return (
-            self._details.for_code(frigidaire.HaclCode.APPLIANCE_STATE).number_value
-            != 0
-        )
+        return self._details.for_code(frigidaire.HaclCode.APPLIANCE_STATE) != 0
 
     @property
     def supported_features(self):
@@ -230,10 +221,7 @@ class FrigidaireDehumidifier(HumidifierEntity):
             return
 
         # Turn on if not currently on.
-        if (
-            self._details.for_code(frigidaire.HaclCode.APPLIANCE_STATE).number_value
-            == 0
-        ):
+        if self._details.for_code(frigidaire.HaclCode.APPLIANCE_STATE) == 0:
             self.turn_on()
 
         self._client.execute_action(
@@ -251,8 +239,6 @@ class FrigidaireDehumidifier(HumidifierEntity):
             self._attr_available = False
         else:
             self._attr_available = (
-                self._details.for_code(
-                    frigidaire.HaclCode.CONNECTIVITY_STATE
-                ).string_value
-                != frigidaire.ConnectivityState.DISCONNECTED.value
+                self._details.for_code(frigidaire.HaclCode.CONNECTIVITY_STATE)
+                != frigidaire.ConnectivityState.DISCONNECTED
             )

--- a/custom_components/frigidaire/humidifier.py
+++ b/custom_components/frigidaire/humidifier.py
@@ -152,6 +152,9 @@ class FrigidaireDehumidifier(HumidifierEntity):
             frigidaire.HaclCode.AC_MODE
         ).number_value
 
+        if frigidaire_mode == frigidaire.Mode.OFF:
+            return MODE_NORMAL
+
         return FRIGIDAIRE_TO_HA_MODE[frigidaire_mode]
 
     @property

--- a/custom_components/frigidaire/manifest.json
+++ b/custom_components/frigidaire/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/frigidaire",
   "requirements": [
-    "frigidaire==0.14"
+    "frigidaire==0.15"
   ],
   "dependencies": [],
   "codeowners": [


### PR DESCRIPTION
Simplifies some of the usage of Enums and ApplianceDetails allowed by 0.15 of the library.

I also slipped a fix in here for when dehumidifiers were returning 'off' as the mode. During all my previous testing this never happened, only the appliance_state changed, but it started happening now. I can split this out into a separate PR if desired.