### PR TITLE
Use async_forward_entry_setups in async_setup_entry

### DIFF
--- a/custom_components/frigidaire/__init__.py
+++ b/custom_components/frigidaire/__init__.py
@@ -29,7 +29,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         setup, entry.data["username"], entry.data["password"]
     )
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 


### PR DESCRIPTION
Greetings! I expect this will resolve #24 
I now have this version running on my HA (OS) instance and it found my dehumidifier and didn't complain about the old method anymore, nor did I notice any errors (so far, so good!)