### PR TITLE
Fix breaking changes to frigidaire API

### DIFF
--- a/custom_components/frigidaire/humidifier.py
+++ b/custom_components/frigidaire/humidifier.py
@@ -51,6 +51,19 @@ async def async_setup_entry(
         get_entities, entry.data["username"], entry.data["password"]
     )
 
+    _LOGGER.warning("Humidifier support temporarily disabled due to an API change and "
+                    "lack of test hardware")
+    """
+    Setting the humidity on the humidifier will raise a FrigidaireException explaining
+    the feature is not implemented because @rothn does not have one of their
+    humidifiers to test on. For the same reason, it's also possible that the humidifier
+    Destination is not correctly detected.
+
+    These issues should be somewhat easily solvable by someone who has a compatible
+    humidifier manually calling `get_appliance_details()` on a humidifier, inspecting the
+    output, then making and testing changes based on climate.py. This can be easily
+    achieved with the frigidaire API in a Jupyter notebook.
+
     async_add_entities(
         [
             FrigidaireDehumidifier(client, appliance)
@@ -59,6 +72,7 @@ async def async_setup_entry(
         ],
         update_before_add=True,
     )
+    """
 
 
 FRIGIDAIRE_TO_HA_MODE = {

--- a/custom_components/frigidaire/manifest.json
+++ b/custom_components/frigidaire/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/frigidaire",
   "requirements": [
-    "frigidaire==0.18.13"
+    "frigidaire==0.18.15"
   ],
   "dependencies": [],
   "codeowners": [


### PR DESCRIPTION
A new API broke the current version of this library, and was noticed in 1/26/2024. This embeds a patched version of the frigidaire dependency temporarily while I wait for a fix to get merged upstream. Additionally, this introduces minor changes to accommodate the new API, as the patched dependency was not able to maintain 100% API compatibility.

Change notes:
* HVACAction is not supported by data we get from new API, so had to be removed (lacks sufficient low-level system state)
* Humidifier temporarily disabled since I don't have a test device. More details in a comment