### PR TITLE
Apply fixes to restore humidifier functionality

### DIFF
--- a/custom_components/frigidaire/manifest.json
+++ b/custom_components/frigidaire/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/frigidaire",
   "requirements": [
-    "frigidaire==0.18.15"
+    "frigidaire==0.18.16"
   ],
   "dependencies": [],
   "codeowners": [


### PR DESCRIPTION
Breaking API changes and a lack of test hardware broke humidifier functionality temporarily. With community input, humidifier functionality has been re-added to this plugin. This also bumps the version of the frigidaire dependency to 0.18.16.

DO NOT MERGE until release 0.18.16 is available with the new dehumidifier functionality and someone has had a chance to test the new package. I will remove this on my own if/when these conditions are met.