### PR TITLE
Provide helpful error message for Frigidaire 429

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 venv/
 __pycache__/
 .idea/
+*.iml

--- a/custom_components/frigidaire/__init__.py
+++ b/custom_components/frigidaire/__init__.py
@@ -23,6 +23,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         except ConnectionError as err:
             raise ConfigEntryNotReady("Cannot connect to Frigidaire") from err
         except frigidaire.FrigidaireException as err:
+            # Handle frigidaire 429 gracefully
+            if "cas_3403" in str(err):
+                raise data_entry_flow.AbortFlow("You have exceeded the maximum number of active sessions. Please log out of another device or wait until an existing session expires.") from err
             raise data_entry_flow.AbortFlow("Frigidaire backend exception") from err
 
     await hass.async_add_executor_job(

--- a/custom_components/frigidaire/__init__.py
+++ b/custom_components/frigidaire/__init__.py
@@ -23,7 +23,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         except ConnectionError as err:
             raise ConfigEntryNotReady("Cannot connect to Frigidaire") from err
         except frigidaire.FrigidaireException as err:
-            raise data_entry_flow.AbortFlow from err
+            raise data_entry_flow.AbortFlow("Frigidaire backend exception") from err
 
     await hass.async_add_executor_job(
         setup, entry.data["username"], entry.data["password"]

--- a/custom_components/frigidaire/__init__.py
+++ b/custom_components/frigidaire/__init__.py
@@ -1,6 +1,8 @@
 """The frigidaire integration."""
 from __future__ import annotations
 
+import traceback
+
 import frigidaire
 
 from homeassistant import data_entry_flow
@@ -24,8 +26,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             raise ConfigEntryNotReady("Cannot connect to Frigidaire") from err
         except frigidaire.FrigidaireException as err:
             # Handle frigidaire 429 gracefully
-            if "cas_3403" in str(err):
-                raise data_entry_flow.AbortFlow("You have exceeded the maximum number of active sessions. Please log out of another device or wait until an existing session expires.") from err
+            if "cas_3403" in traceback.format_exc():
+                raise data_entry_flow.AbortFlow("You have exceeded Frigidaire's maximum number of active sessions. Please log out of another device or wait until an existing session expires.") from err
             raise data_entry_flow.AbortFlow("Frigidaire backend exception") from err
 
     await hass.async_add_executor_job(


### PR DESCRIPTION
Previously, the code would swallow Frigidaire 429s, leading to confusion from users

While Frigidaire doesn't say what a session timeout is, this will at least give users a sense of what went wrong