### PR TITLE
Various improvements to reduce number of auths

### DIFF
--- a/custom_components/frigidaire/__init__.py
+++ b/custom_components/frigidaire/__init__.py
@@ -1,6 +1,7 @@
 """The frigidaire integration."""
 from __future__ import annotations
 
+import os
 import traceback
 
 import frigidaire
@@ -10,6 +11,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
+from .config_flow import load_auth, save_auth
 from .const import DOMAIN, PLATFORMS
 
 
@@ -17,11 +19,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up frigidaire from a config entry."""
     hass.data.setdefault(DOMAIN, {})
 
-    def setup(username: str, password: str) -> frigidaire.Frigidaire:
+    def setup(username: str, password: str) -> None:
+        auth_path = os.path.join(hass.config.path(), "frigidaire.conf")
+
         try:
-            hass.data[DOMAIN][entry.entry_id] = frigidaire.Frigidaire(
-                username, password, timeout=60
+            session_key, regional_base_url = load_auth(auth_path)
+            client = frigidaire.Frigidaire(
+                username=username,
+                password=password,
+                timeout=60,
+                session_key=session_key,
+                regional_base_url=regional_base_url
             )
+            save_auth(auth_path, client.session_key, client.regional_base_url)
+
+            hass.data[DOMAIN][entry.entry_id] = client
         except ConnectionError as err:
             raise ConfigEntryNotReady("Cannot connect to Frigidaire") from err
         except frigidaire.FrigidaireException as err:

--- a/custom_components/frigidaire/__init__.py
+++ b/custom_components/frigidaire/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .config_flow import load_auth, save_auth
+from .config_flow import load_auth, save_auth, AUTH_FILE
 from .const import DOMAIN, PLATFORMS
 
 
@@ -20,7 +20,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
 
     def setup(username: str, password: str) -> None:
-        auth_path = os.path.join(hass.config.path(), "frigidaire.conf")
+        auth_path: str = os.path.join(hass.config.path(), AUTH_FILE)
 
         try:
             session_key, regional_base_url = load_auth(auth_path)

--- a/custom_components/frigidaire/config_flow.py
+++ b/custom_components/frigidaire/config_flow.py
@@ -1,8 +1,10 @@
 """Config flow for frigidaire integration."""
 from __future__ import annotations
 
+import json
 import logging
-from typing import Any
+import os
+from typing import Any, Optional
 
 import frigidaire
 import voluptuous as vol
@@ -19,6 +21,20 @@ _LOGGER = logging.getLogger(__name__)
 STEP_USER_DATA_SCHEMA = vol.Schema({"username": str, "password": str})
 
 
+def load_auth(auth_path: str) -> tuple[Optional[str], Optional[str]]:
+    if os.path.exists(auth_path):
+        if os.path.getsize(auth_path) > 0:
+            with open(auth_path, 'r') as f:
+                obj: dict = json.loads(f.read())
+                return obj.get('session_key'), obj.get('regional_base_url')
+    return None, None
+
+
+def save_auth(auth_path: str, session_key: str, regional_base_url: str) -> None:
+    with open(auth_path, 'w') as f:
+        json.dump({session_key, regional_base_url}, f, ensure_ascii=False, indent=4)
+
+
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]):
     """Validate the user input allows us to connect.
 
@@ -26,8 +42,19 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]):
     """
 
     def setup(username: str, password: str) -> list[frigidaire.Appliance]:
+        auth_path = os.path.join(hass.config.path(), "frigidaire.conf")
+
         try:
-            client = frigidaire.Frigidaire(username, password, timeout=60)
+            session_key, regional_base_url = load_auth(auth_path)
+            client = frigidaire.Frigidaire(
+                username=username,
+                password=password,
+                timeout=60,
+                session_key=session_key,
+                regional_base_url=regional_base_url
+            )
+            save_auth(auth_path, client.session_key, client.regional_base_url)
+
             return client.get_appliances()
         except frigidaire.FrigidaireException as err:
             if "Failed to authenticate" in str(err):

--- a/custom_components/frigidaire/config_flow.py
+++ b/custom_components/frigidaire/config_flow.py
@@ -37,7 +37,7 @@ def load_auth(auth_path: str) -> tuple[Optional[str], Optional[str]]:
 
 def save_auth(auth_path: str, session_key: str, regional_base_url: str) -> None:
     with open(auth_path, 'w') as f:
-        json.dump({session_key, regional_base_url}, f, ensure_ascii=False, indent=4)
+        json.dump({session_key: session_key, regional_base_url: regional_base_url}, f, ensure_ascii=False, indent=4)
 
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]):

--- a/custom_components/frigidaire/config_flow.py
+++ b/custom_components/frigidaire/config_flow.py
@@ -20,13 +20,18 @@ _LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema({"username": str, "password": str})
 
+AUTH_FILE = 'frigidaire.json'
+
 
 def load_auth(auth_path: str) -> tuple[Optional[str], Optional[str]]:
-    if os.path.exists(auth_path):
-        if os.path.getsize(auth_path) > 0:
-            with open(auth_path, 'r') as f:
-                obj: dict = json.loads(f.read())
-                return obj.get('session_key'), obj.get('regional_base_url')
+    if not os.path.exists(auth_path):
+        with open(auth_path, 'w'):
+            pass
+
+    if os.path.getsize(auth_path) > 0:
+        with open(auth_path, 'r') as f:
+            obj: dict = json.loads(f.read())
+            return obj.get('session_key'), obj.get('regional_base_url')
     return None, None
 
 
@@ -42,7 +47,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]):
     """
 
     def setup(username: str, password: str) -> list[frigidaire.Appliance]:
-        auth_path = os.path.join(hass.config.path(), "frigidaire.conf")
+        auth_path = os.path.join(hass.config.path(), AUTH_FILE)
 
         try:
             session_key, regional_base_url = load_auth(auth_path)

--- a/custom_components/frigidaire/manifest.json
+++ b/custom_components/frigidaire/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/frigidaire",
   "requirements": [
-    "frigidaire==0.18.20"
+    "frigidaire==0.18.21"
   ],
   "dependencies": [],
   "codeowners": [

--- a/custom_components/frigidaire/manifest.json
+++ b/custom_components/frigidaire/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/frigidaire",
   "requirements": [
-    "frigidaire==0.18.19"
+    "frigidaire==0.18.20"
   ],
   "dependencies": [],
   "codeowners": [


### PR DESCRIPTION
Reduces the number of times the plugin will attempt to authenticate to reduce the chance of getting 429s as seen in #58 #59

**Pulls in https://github.com/bm1549/frigidaire/pull/33**
- Refuses to re-authenticate if the exception was due to too many authentications
- Handles b'' response from server to prevent unnecessary exceptions and re-authentication

**Pulls in https://github.com/bm1549/frigidaire/pull/34**
- Removes restriction for Farehnheit temp ranges

Additional change to save and load `session_key` and `regional_base_url` to reduce the chance of re-authenticating on restart

Note: The `session_key` is only saved on initial auth and not on a subsequent re-authentication, so it may be stale when the service starts. A future improvement here would be to save the `session_key` again after re-authentication or before stopping the service