### PR TITLE
Set temperature when device is turned on

### DIFF
--- a/custom_components/frigidaire/climate.py
+++ b/custom_components/frigidaire/climate.py
@@ -263,6 +263,12 @@ class FrigidaireClimate(ClimateEntity):
                 self._appliance, frigidaire.Action.set_power(frigidaire.Power.ON)
             )
 
+            # temperature reverts to default when the device is turned on
+            self._client.execute_action(
+                self._appliance,
+                frigidaire.Action.set_temperature(self.target_temperature)
+            )
+
         self._client.execute_action(
             self._appliance,
             frigidaire.Action.set_mode(HA_TO_FRIGIDAIRE_HVAC_MODE[hvac_mode]),


### PR DESCRIPTION
QOL change to set temperature when the device is turned on

Currently, the device sets a default temperature when turning on. This change makes it so that the device sets back to the temperature previously set, which is more intuitive for HA users

