### PR TITLE
Return ambient temp in F or C based on unit setting

### DIFF
--- a/custom_components/frigidaire/climate.py
+++ b/custom_components/frigidaire/climate.py
@@ -189,7 +189,10 @@ class FrigidaireClimate(ClimateEntity):
     @property
     def current_temperature(self):
         """Return the current temperature."""
-        return self._details.get(frigidaire.Detail.AMBIENT_TEMPERATURE_F)
+        if self.temperature_unit == TEMP_FAHRENHEIT:
+            return self._details.get(frigidaire.Detail.AMBIENT_TEMPERATURE_F)
+        else:
+            return self._details.get(frigidaire.Detail.AMBIENT_TEMPERATURE_C)
 
     @property
     def fan_mode(self):


### PR DESCRIPTION
Return the ambient temperature according to the configured temperature_unit rather than always returning degrees Fahrenheit.

Fixes #65.