### PR TITLE
Set temperature using native units

### DIFF
--- a/custom_components/frigidaire/climate.py
+++ b/custom_components/frigidaire/climate.py
@@ -232,8 +232,15 @@ class FrigidaireClimate(ClimateEntity):
             return
         temperature = int(temperature)
 
+        if self.temperature_unit == TEMP_FAHRENHEIT:
+            action = frigidaire.Action.set_temperature_f(temperature)
+            _LOGGER.debug("Setting temperature to int({}) via set_temperature_f".format(temperature))
+        else:
+            action = frigidaire.Action.set_temperature_c(temperature)
+            _LOGGER.debug("Setting temperature to int({}) via set_temperature_c".format(temperature))
+
         self._client.execute_action(
-            self._appliance, frigidaire.Action.set_temperature(temperature)
+            self._appliance, action
         )
 
     def set_fan_mode(self, fan_mode):


### PR DESCRIPTION
**Relies on breaking API change in Frigidaire client https://github.com/bm1549/frigidaire/pull/37**

Call (new) frigidaire client methods set_temperature_f or set_temperature_c to match what our configured temperature_unit is.

Previously, we called set_temperature(), which assumed its target temperature argument was provided in degrees Fahrenheit. If our units were configured to degrees Celsius, this would provide a Celsius value as a Fahrenheit argument, generally setting a target temperature below the minimum allowed Fahrenheit target temperature.

By calling the client method which matches our configured units, we avoid any temperature unit conversions and directly call the correct underlying Frigidaire SET_TEMPERATURE_F/C action.

Fixes remaining issues in #56