### PR TITLE
fix #76: Update bin_full attribute to reflect correct status

### DIFF
--- a/custom_components/frigidaire/humidifier.py
+++ b/custom_components/frigidaire/humidifier.py
@@ -180,7 +180,13 @@ class FrigidaireDehumidifier(HumidifierEntity):
         bin_full = False
         alerts = self._details.get(frigidaire.Detail.ALERTS)
         if alerts is not None:
-            bin_full = (frigidaire.Alert.BUCKET_FULL in alerts)
+            # 1) Old approach
+            if frigidaire.Alert.BUCKET_FULL in alerts:
+                bin_full = True
+
+            # 2) New approach
+            if any(alert.get("code") == "BUCKET_FULL" for alert in alerts):
+                bin_full = True
 
         # Fallback to waterBucketLevel if alert is not set
         if not bin_full:

--- a/custom_components/frigidaire/humidifier.py
+++ b/custom_components/frigidaire/humidifier.py
@@ -177,8 +177,18 @@ class FrigidaireDehumidifier(HumidifierEntity):
         }
 
         # The following attributes only exist on some models of dehumidifier
-        if (alerts := self._details.get(frigidaire.Detail.ALERTS)) is not None:
-            attrib["bin_full"] = frigidaire.Alert.BUCKET_FULL in alerts
+        bin_full = False
+        alerts = self._details.get(frigidaire.Detail.ALERTS)
+        if alerts is not None:
+            bin_full = (frigidaire.Alert.BUCKET_FULL in alerts)
+
+        # Fallback to waterBucketLevel if alert is not set
+        if not bin_full:
+            water_bucket_level = self._details.get(frigidaire.Detail.WATER_BUCKET_LEVEL)
+            if water_bucket_level == 1:
+                bin_full = True
+
+        attrib["bin_full"] = bin_full
 
         return attrib
 


### PR DESCRIPTION
**Fix for Issue #76: Correct bin_full Attribute on Dehumidifiers**

This PR fixes the bin_full attribute, ensuring it correctly reflects the dehumidifier's status. The previous method has been retained since it's unclear whether this issue stems from an API change or is specific to certain devices.

**Tested and confirmed working with my device.**