### PR TITLE
Bump frigidaire to 0.18.30

### DIFF
--- a/custom_components/frigidaire/manifest.json
+++ b/custom_components/frigidaire/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/bm1549/home-assistant-frigidaire/issues",
   "requirements": [
-    "frigidaire==0.18.29"
+    "frigidaire==0.18.30"
   ],
   "version": "0.1.9"
 }


### PR DESCRIPTION
## Summary
- Bumps `frigidaire` library from 0.18.29 to 0.18.30.

## Why
0.18.30 contains [bm1549/frigidaire#51](https://github.com/bm1549/frigidaire/pull/51), which maps the "Eagle" platform codename to `DEHUMIDIFIER` and reorders the destination-inference logic to check DH-exclusive property keys before AC keys. Without this, the Gallery 50-pint WiFi dehumidifier (GHDD5035W1) was misclassified as an AC and crashed this integration's climate platform with `KeyError: None` on the temperature unit lookup.

## Test plan
- [ ] Reporter from bm1549/frigidaire#50 confirms the Eagle device loads as a humidifier entity, not a climate entity.
- [ ] Existing AC and DH devices continue to function (unchanged code path).