### PR TITLE
Bump frigidaire to 0.18.32

### DIFF
--- a/custom_components/frigidaire/manifest.json
+++ b/custom_components/frigidaire/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/bm1549/home-assistant-frigidaire/issues",
   "requirements": [
-    "frigidaire==0.18.30"
+    "frigidaire==0.18.32"
   ],
   "version": "0.1.10"
 }


### PR DESCRIPTION
## Summary
- Bump `frigidaire` requirement from 0.18.30 → 0.18.32. Picks up the new ruff + mypy linting/type-checking pipeline and accompanying type/format cleanup in the upstream library (bm1549/frigidaire#53). No behavior changes in the library — same OAuth flow, same `Frigidaire`/`Appliance`/`Action` surface.

## Test plan
- [x] hassfest validation (CI)
- [x] HACS validation (CI)
- [ ] Local install + restart HA, verify climate/humidifier entities still load

🤖 Generated with [Claude Code](https://claude.com/claude-code)