### PR TITLE
ci: add dependabot config for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with a weekly schedule for the `github-actions` ecosystem.
- Pip is intentionally omitted: the only Python dep (`frigidaire`) is pinned in `custom_components/frigidaire/manifest.json`, which dependabot's pip ecosystem does not read.

## Test plan
- [ ] Dependabot picks up the config and starts opening update PRs for workflow actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)