### PR TITLE
Bump frigidaire to 0.18.41

### DIFF
--- a/custom_components/frigidaire/manifest.json
+++ b/custom_components/frigidaire/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/bm1549/home-assistant-frigidaire/issues",
   "requirements": [
-    "frigidaire==0.18.32"
+    "frigidaire==0.18.41"
   ],
   "version": "0.1.12"
 }


### PR DESCRIPTION
Auto-generated by the frigidaire publish workflow to update the library pin to `0.18.41`.