### PR TITLE
ci: use gh CLI for release creation instead of softprops

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,9 @@ jobs:
           git push --tags
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.bump.outputs.version }}
-          name: ${{ steps.bump.outputs.version }}
-          generate_release_notes: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.bump.outputs.version }}" \
+            --title "${{ steps.bump.outputs.version }}" \
+            --generate-notes


### PR DESCRIPTION
## Summary
Replace `softprops/action-gh-release@v2` with a `gh release create` shell step. Drops a third-party action with no behavioral change.

The action was only setting `tag_name`, `name`, and `generate_release_notes`, all of which map directly to `gh release create <tag> --title ... --generate-notes`. `gh` is preinstalled on GitHub-hosted runners.

This also obsoletes dependabot PR #105 (softprops 2→3); will close that on merge.

## Test plan
- [ ] Validate workflows pass on this PR.
- [ ] On merge, confirm the release workflow runs and a new GitHub release is created with auto-generated notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)