### PR TITLE
ci: add ruff lint, format, and pre-commit hook

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: pip install ruff==0.6.9
+      - run: ruff check .
+      - run: ruff format --check .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/custom_components/frigidaire/__init__.py
+++ b/custom_components/frigidaire/__init__.py
@@ -1,17 +1,18 @@
 """The frigidaire integration."""
+
 from __future__ import annotations
 
 import os
 import traceback
-
-import frigidaire
 
 from homeassistant import data_entry_flow
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .config_flow import load_auth, save_auth, AUTH_FILE
+import frigidaire
+
+from .config_flow import AUTH_FILE, load_auth, save_auth
 from .const import DOMAIN, PLATFORMS
 
 
@@ -29,7 +30,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 password=password,
                 timeout=60,
                 session_key=session_key,
-                regional_base_url=regional_base_url
+                regional_base_url=regional_base_url,
             )
             save_auth(auth_path, client.session_key, client.regional_base_url)
 
@@ -39,12 +40,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         except frigidaire.FrigidaireException as err:
             # Handle frigidaire 429 gracefully
             if "cas_3403" in traceback.format_exc():
-                raise data_entry_flow.AbortFlow("You have exceeded Frigidaire's maximum number of active sessions. Please log out of another device or wait until an existing session expires.") from err
+                raise data_entry_flow.AbortFlow(
+                    "You have exceeded Frigidaire's maximum number of active sessions. "
+                    "Please log out of another device or wait until an existing session expires."
+                ) from err
             raise data_entry_flow.AbortFlow("Frigidaire backend exception") from err
 
-    await hass.async_add_executor_job(
-        setup, entry.data["username"], entry.data["password"]
-    )
+    await hass.async_add_executor_job(setup, entry.data["username"], entry.data["password"])
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/frigidaire/climate.py
+++ b/custom_components/frigidaire/climate.py
@@ -1,10 +1,10 @@
 """ClimateEntity for frigidaire integration."""
+
 from __future__ import annotations
 
 import logging
-from typing import Optional, List, Mapping, Any, Dict
-
-import frigidaire
+from collections.abc import Mapping
+from typing import Any
 
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
@@ -13,13 +13,15 @@ from homeassistant.components.climate.const import (
     FAN_LOW,
     FAN_MEDIUM,
     FAN_OFF,
-    HVACMode,
     ClimateEntityFeature,
+    HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+import frigidaire
 
 from .const import DOMAIN
 
@@ -33,18 +35,14 @@ def _normalize_enum_value(value):
     return value
 
 
-async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
-) -> None:
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
     """Set up frigidaire from a config entry."""
     client = hass.data[DOMAIN][entry.entry_id]
 
-    def get_entities(username: str, password: str) -> List[frigidaire.Appliance]:
+    def get_entities(username: str, password: str) -> list[frigidaire.Appliance]:
         return client.get_appliances()
 
-    appliances = await hass.async_add_executor_job(
-        get_entities, entry.data["username"], entry.data["password"]
-    )
+    appliances = await hass.async_add_executor_job(get_entities, entry.data["username"], entry.data["password"])
 
     async_add_entities(
         [
@@ -111,15 +109,17 @@ class FrigidaireClimate(ClimateEntity):
 
         self._client: frigidaire.Frigidaire = client
         self._appliance: frigidaire.Appliance = appliance
-        self._details: Optional[Dict] = None
+        self._details: dict | None = None
 
         # Entity Class Attributes
         self._attr_unique_id = self._appliance.appliance_id
         self._attr_name = self._appliance.nickname
-        self._attr_supported_features = (ClimateEntityFeature.TARGET_TEMPERATURE |
-                                         ClimateEntityFeature.FAN_MODE |
-                                         ClimateEntityFeature.TURN_OFF |
-                                         ClimateEntityFeature.TURN_ON)
+        self._attr_supported_features = (
+            ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.FAN_MODE
+            | ClimateEntityFeature.TURN_OFF
+            | ClimateEntityFeature.TURN_ON
+        )
         self._attr_target_temperature_step = 1
 
         # Although we can access the Frigidaire API to get updates, they are
@@ -180,9 +180,7 @@ class FrigidaireClimate(ClimateEntity):
     @property
     def temperature_unit(self):
         """Return the unit of measurement which this thermostat uses."""
-        unit = _normalize_enum_value(self._details.get(
-            frigidaire.Detail.TEMPERATURE_REPRESENTATION
-        ))
+        unit = _normalize_enum_value(self._details.get(frigidaire.Detail.TEMPERATURE_REPRESENTATION))
 
         return FRIGIDAIRE_TO_HA_UNIT[unit]
 
@@ -238,9 +236,7 @@ class FrigidaireClimate(ClimateEntity):
     @property
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         return {
-            "check_filter": bool(
-                _normalize_enum_value(self._details.get(frigidaire.Detail.FILTER_STATE)) == "CHANGE"
-            ),
+            "check_filter": bool(_normalize_enum_value(self._details.get(frigidaire.Detail.FILTER_STATE)) == "CHANGE"),
         }
 
     def set_temperature(self, **kwargs):
@@ -251,10 +247,8 @@ class FrigidaireClimate(ClimateEntity):
         temperature = int(temperature)
         temperature_unit = HA_TO_FRIGIDAIRE_UNIT[self.temperature_unit]
 
-        _LOGGER.debug("Setting temperature to int({}) {}".format(temperature, self.temperature_unit))
-        self._client.execute_action(
-            self._appliance, frigidaire.Action.set_temperature(temperature, temperature_unit)
-        )
+        _LOGGER.debug(f"Setting temperature to int({temperature}) {self.temperature_unit}")
+        self._client.execute_action(self._appliance, frigidaire.Action.set_temperature(temperature, temperature_unit))
 
     def set_fan_mode(self, fan_mode):
         """Set new target fan mode."""
@@ -268,9 +262,7 @@ class FrigidaireClimate(ClimateEntity):
     def set_hvac_mode(self, hvac_mode):
         """Set new target operation mode."""
         if hvac_mode == HVACMode.OFF:
-            self._client.execute_action(
-                self._appliance, frigidaire.Action.set_power(frigidaire.Power.OFF)
-            )
+            self._client.execute_action(self._appliance, frigidaire.Action.set_power(frigidaire.Power.OFF))
             return
 
         # Guard against unexpected hvac modes
@@ -279,14 +271,11 @@ class FrigidaireClimate(ClimateEntity):
 
         # Turn on if not currently on.
         if _normalize_enum_value(self._details.get(frigidaire.Detail.MODE)) == frigidaire.Mode.OFF:
-            self._client.execute_action(
-                self._appliance, frigidaire.Action.set_power(frigidaire.Power.ON)
-            )
+            self._client.execute_action(self._appliance, frigidaire.Action.set_power(frigidaire.Power.ON))
 
             # temperature reverts to default when the device is turned on
             self._client.execute_action(
-                self._appliance,
-                frigidaire.Action.set_temperature(int(self.target_temperature))
+                self._appliance, frigidaire.Action.set_temperature(int(self.target_temperature))
             )
 
         self._client.execute_action(

--- a/custom_components/frigidaire/config_flow.py
+++ b/custom_components/frigidaire/config_flow.py
@@ -1,18 +1,19 @@
 """Config flow for frigidaire integration."""
+
 from __future__ import annotations
 
 import json
 import logging
 import os
-from typing import Any, Optional
+from typing import Any
 
-import frigidaire
 import voluptuous as vol
-
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
+
+import frigidaire
 
 from .const import DOMAIN
 
@@ -20,24 +21,24 @@ _LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema({"username": str, "password": str})
 
-AUTH_FILE = 'frigidaire.json'
+AUTH_FILE = "frigidaire.json"
 
 
-def load_auth(auth_path: str) -> tuple[Optional[str], Optional[str]]:
+def load_auth(auth_path: str) -> tuple[str | None, str | None]:
     if not os.path.exists(auth_path):
-        with open(auth_path, 'w'):
+        with open(auth_path, "w"):
             pass
 
     if os.path.getsize(auth_path) > 0:
-        with open(auth_path, 'r') as f:
+        with open(auth_path) as f:
             obj: dict = json.loads(f.read())
-            return obj.get('session_key'), obj.get('regional_base_url')
+            return obj.get("session_key"), obj.get("regional_base_url")
     return None, None
 
 
 def save_auth(auth_path: str, session_key: str, regional_base_url: str) -> None:
-    with open(auth_path, 'w') as f:
-        json.dump({'session_key': session_key, 'regional_base_url': regional_base_url}, f, ensure_ascii=False, indent=4)
+    with open(auth_path, "w") as f:
+        json.dump({"session_key": session_key, "regional_base_url": regional_base_url}, f, ensure_ascii=False, indent=4)
 
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]):
@@ -56,7 +57,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]):
                 password=password,
                 timeout=60,
                 session_key=session_key,
-                regional_base_url=regional_base_url
+                regional_base_url=regional_base_url,
             )
             save_auth(auth_path, client.session_key, client.regional_base_url)
 
@@ -67,9 +68,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]):
 
             raise CannotConnect from err
 
-    appliances = await hass.async_add_executor_job(
-        setup, data["username"], data["password"]
-    )
+    appliances = await hass.async_add_executor_job(setup, data["username"], data["password"])
 
     if len(appliances) == 0:
         raise NoAppliances
@@ -83,14 +82,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Handle the initial step."""
         if user_input is None:
-            return self.async_show_form(
-                step_id="user", data_schema=STEP_USER_DATA_SCHEMA
-            )
+            return self.async_show_form(step_id="user", data_schema=STEP_USER_DATA_SCHEMA)
 
         errors = {}
 
@@ -108,9 +103,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         else:
             return self.async_create_entry(title=DOMAIN, data=user_input)
 
-        return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
-        )
+        return self.async_show_form(step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors)
 
 
 class NoAppliances(HomeAssistantError):

--- a/custom_components/frigidaire/humidifier.py
+++ b/custom_components/frigidaire/humidifier.py
@@ -1,24 +1,27 @@
 """ClimateEntity for frigidaire integration."""
+
 from __future__ import annotations
 
 import logging
-from typing import List, Any, Mapping, Optional, Dict
+from collections.abc import Mapping
+from typing import Any
 
-import frigidaire
 import voluptuous as vol
-
-from homeassistant.components.humidifier import HumidifierEntity, HumidifierDeviceClass
+from homeassistant.components.humidifier import HumidifierDeviceClass, HumidifierEntity
 from homeassistant.components.humidifier.const import (
-    MODE_BOOST,
-    MODE_SLEEP,
     MODE_AUTO,
+    MODE_BOOST,
     MODE_NORMAL,
+    MODE_SLEEP,
     HumidifierEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv, entity_platform
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+import frigidaire
 
 from .const import DOMAIN
 
@@ -37,9 +40,7 @@ FAN_MEDIUM = "medium"
 FAN_HIGH = "high"
 
 
-async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
-) -> None:
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
     """Set up frigidaire from a config entry."""
     platform = entity_platform.async_get_current_platform()
     platform.async_register_entity_service(
@@ -50,12 +51,10 @@ async def async_setup_entry(
 
     client = hass.data[DOMAIN][entry.entry_id]
 
-    def get_entities(username: str, password: str) -> List[frigidaire.Appliance]:
+    def get_entities(username: str, password: str) -> list[frigidaire.Appliance]:
         return client.get_appliances()
 
-    appliances = await hass.async_add_executor_job(
-        get_entities, entry.data["username"], entry.data["password"]
-    )
+    appliances = await hass.async_add_executor_job(get_entities, entry.data["username"], entry.data["password"])
 
     async_add_entities(
         [
@@ -98,7 +97,7 @@ class FrigidaireDehumidifier(HumidifierEntity):
 
         self._client: frigidaire.Frigidaire = client
         self._appliance: frigidaire.Appliance = appliance
-        self._details: Optional[Dict] = None
+        self._details: dict | None = None
 
         # Entity Class Attributes
         self._attr_unique_id = self._appliance.appliance_id
@@ -143,7 +142,10 @@ class FrigidaireDehumidifier(HumidifierEntity):
 
     @property
     def is_on(self):
-        return _normalize_enum_value(self._details.get(frigidaire.Detail.APPLIANCE_STATE)) == frigidaire.ApplianceState.RUNNING
+        return (
+            _normalize_enum_value(self._details.get(frigidaire.Detail.APPLIANCE_STATE))
+            == frigidaire.ApplianceState.RUNNING
+        )
 
     @property
     def supported_features(self):
@@ -216,14 +218,10 @@ class FrigidaireDehumidifier(HumidifierEntity):
         return 85
 
     def turn_on(self, **kwargs: Any) -> None:
-        self._client.execute_action(
-            self._appliance, frigidaire.Action.set_power(frigidaire.Power.ON)
-        )
+        self._client.execute_action(self._appliance, frigidaire.Action.set_power(frigidaire.Power.ON))
 
     def turn_off(self, **kwargs: Any) -> None:
-        self._client.execute_action(
-            self._appliance, frigidaire.Action.set_power(frigidaire.Power.OFF)
-        )
+        self._client.execute_action(self._appliance, frigidaire.Action.set_power(frigidaire.Power.OFF))
 
     def set_humidity(self, humidity: int):
         """Set new target humidity."""
@@ -233,9 +231,7 @@ class FrigidaireDehumidifier(HumidifierEntity):
         humidity = 5 * round(humidity / 5)
         # We have to be in dry mode to set a target humidity
         self.set_mode(MODE_NORMAL)
-        self._client.execute_action(
-            self._appliance, frigidaire.Action.set_humidity(humidity)
-        )
+        self._client.execute_action(self._appliance, frigidaire.Action.set_humidity(humidity))
 
     def set_fan_mode(self, fan_mode):
         """Set new target fan mode."""
@@ -257,9 +253,7 @@ class FrigidaireDehumidifier(HumidifierEntity):
         if _normalize_enum_value(self._details.get(frigidaire.Detail.APPLIANCE_STATE)) == frigidaire.ApplianceState.OFF:
             self.turn_on()
 
-        self._client.execute_action(
-            self._appliance, frigidaire.Action.set_mode(HA_TO_FRIGIDAIRE_MODE[mode])
-        )
+        self._client.execute_action(self._appliance, frigidaire.Action.set_mode(HA_TO_FRIGIDAIRE_MODE[mode]))
 
     def update(self):
         """Retrieve latest state and updates the details."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.ruff]
+line-length = 120
+target-version = "py310"
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "F",   # pyflakes
+    "W",   # pycodestyle warnings
+    "I",   # isort
+    "B",   # flake8-bugbear
+    "UP",  # pyupgrade
+]


### PR DESCRIPTION
## Summary
Mirror the `frigidaire` library's ruff setup on this repo:
- `pyproject.toml`: ruff config — line-length 120, target py310, rule families `E F W I B UP`.
- `.pre-commit-config.yaml`: ruff + ruff-format hooks.
- `.github/workflows/lint.yml`: CI job running `ruff check` and `ruff format --check`.

## Initial fixes applied
Auto-applied by `ruff check --fix` and `ruff format`:
- Import sorting (`I001`)
- Deprecated typing aliases → builtins/`collections.abc` (`UP006`, `UP035`, `UP045`)
- Drop unnecessary `"r"` mode from `open()` (`UP015`)
- `.format()` → f-string (`UP032`)

Manual fix:
- One 163-char error-message string in `__init__.py` broken across two lines (`E501`).

No runtime behavior change.

## Test plan
- [x] Lint CI passes on this PR.
- [x] HACS / hassfest validation still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
