### PR TITLE
Bump frigidaire to 0.18.44

### DIFF
--- a/custom_components/frigidaire/manifest.json
+++ b/custom_components/frigidaire/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/bm1549/home-assistant-frigidaire/issues",
   "requirements": [
-    "frigidaire==0.18.43"
+    "frigidaire==0.18.44"
   ],
   "version": "0.1.16"
 }


### PR DESCRIPTION
Automated bump of the `frigidaire` library pin to **0.18.44**.

- Release notes: https://github.com/bm1549/frigidaire/releases/tag/0.18.44
- Diff: https://github.com/bm1549/frigidaire/compare/0.18.43...0.18.44
- PyPI: https://pypi.org/project/frigidaire/0.18.44/

Updates `custom_components/frigidaire/manifest.json`.