### PR TITLE
Add preset and swing mode support for climate entity and Frigidaire integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@
 4. Go to Configuration > Integrations and add the Frigidaire integration (should be in the list now)
 5. It should prompt you for your username (email) and password. Fill those in and hit Submit
 6. It should say it successfully added N number of climate entities.
+
+## HACS Integration
+Pending merge of https://github.com/hacs/default/pull/2739

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![](https://img.shields.io/github/release/kriodoxis/home-assistant-frigidaire/all.svg?style=for-the-badge)](https://github.com/kriodoxis/home-assistant-frigidaire/releases)
+[![](https://img.shields.io/github/release/bm1549/home-assistant-frigidaire/all.svg?style=for-the-badge)](https://github.com/bm1549/home-assistant-frigidaire/releases)
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/custom-components/hacs)
 [![](https://img.shields.io/github/license/bm1549/home-assistant-frigidaire?style=for-the-badge)](LICENSE)
-[![](https://img.shields.io/badge/MAINTAINER-%40kriodoxis?style=for-the-badge)](https://github.com/bm1549)
+[![](https://img.shields.io/badge/MAINTAINER-%40bm154969-red?style=for-the-badge)](https://github.com/bm1549)
 [![](https://img.shields.io/badge/COMMUNITY-FORUM-success?style=for-the-badge)](https://community.home-assistant.io)
 
 # Home Assistant Custom Component for Frigidaire

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![](https://img.shields.io/github/release/bm1549/home-assistant-frigidaire/all.svg?style=for-the-badge)](https://github.com/bm1549/home-assistant-frigidaire/releases)
+[![](https://img.shields.io/github/release/kriodoxis/home-assistant-frigidaire/all.svg?style=for-the-badge)](https://github.com/kriodoxis/home-assistant-frigidaire/releases)
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/custom-components/hacs)
 [![](https://img.shields.io/github/license/bm1549/home-assistant-frigidaire?style=for-the-badge)](LICENSE)
-[![](https://img.shields.io/badge/MAINTAINER-%40bm154969-red?style=for-the-badge)](https://github.com/bm1549)
+[![](https://img.shields.io/badge/MAINTAINER-%40kriodoxis?style=for-the-badge)](https://github.com/bm1549)
 [![](https://img.shields.io/badge/COMMUNITY-FORUM-success?style=for-the-badge)](https://community.home-assistant.io)
 
 # Home Assistant Custom Component for Frigidaire
@@ -13,6 +13,3 @@
 4. Go to Configuration > Integrations and add the Frigidaire integration (should be in the list now)
 5. It should prompt you for your username (email) and password. Fill those in and hit Submit
 6. It should say it successfully added N number of climate entities.
-
-## HACS Integration
-Pending merge of https://github.com/hacs/default/pull/2739

--- a/custom_components/frigidaire/climate.py
+++ b/custom_components/frigidaire/climate.py
@@ -18,6 +18,7 @@ from homeassistant.components.climate.const import (
     SWING_OFF,
     SWING_VERTICAL,
     HVACMode,
+    HVACAction,
     ClimateEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -28,6 +29,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+OPTIMISTIC_WINDOW = 5  # seconds to hold optimistic state after setting
 
 
 def _normalize_enum_value(value):
@@ -114,7 +117,7 @@ HA_TO_FRIGIDAIRE_SWING = {
 }
 
 HA_TO_FRIGIDAIRE_HVAC_MODE = {
-    HVACMode.AUTO: frigidaire.Mode.ECO,
+    HVACMode.AUTO: frigidaire.Mode.AUTO,
     HVACMode.FAN_ONLY: frigidaire.Mode.FAN,
     HVACMode.COOL: frigidaire.Mode.COOL,
     HVACMode.OFF: frigidaire.Mode.OFF,
@@ -136,6 +139,14 @@ class FrigidaireClimate(ClimateEntity):
         self._client: frigidaire.Frigidaire = client
         self._appliance: frigidaire.Appliance = appliance
         self._details: Optional[Dict] = None
+
+        # Optimistic state overrides
+        self._optimistic_hvac_mode: Optional[HVACMode] = None
+        self._optimistic_fan_mode: Optional[str] = None
+        self._optimistic_preset_mode: Optional[str] = None
+        self._optimistic_swing_mode: Optional[str] = None
+        self._optimistic_temperature: Optional[float] = None
+        self._optimistic_until: Optional[float] = None
 
         # Entity Class Attributes
         self._attr_unique_id = self._appliance.appliance_id
@@ -187,6 +198,16 @@ class FrigidaireClimate(ClimateEntity):
     def unique_id(self):
         """Return unique ID based on Frigidaire ID."""
         return self._attr_unique_id
+    
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._appliance.appliance_id)},
+            "name": self._appliance.nickname,
+            "manufacturer": "Frigidaire",
+            "model": "AC",
+            "via_device": (DOMAIN, self._appliance.appliance_id),
+        }
 
     @property
     def name(self):
@@ -202,6 +223,46 @@ class FrigidaireClimate(ClimateEntity):
     def hvac_modes(self):
         """List of available operation modes."""
         return self._attr_hvac_modes
+    
+    @property
+    def hvac_action(self) -> HVACAction | None:
+        """Return the current running hvac operation."""
+        if not self._details:
+            return None
+
+        # During optimistic window, derive action directly from optimistic mode
+        if self._is_optimistic() and self._optimistic_hvac_mode is not None:
+            if self._optimistic_hvac_mode == HVACMode.OFF:
+                return HVACAction.OFF
+            elif self._optimistic_hvac_mode == HVACMode.COOL:
+                return HVACAction.COOLING
+            elif self._optimistic_hvac_mode == HVACMode.AUTO:
+                return HVACAction.COOLING
+            elif self._optimistic_hvac_mode == HVACMode.FAN_ONLY:
+                return HVACAction.FAN
+            elif self._optimistic_hvac_mode == HVACMode.DRY:
+                return HVACAction.DRYING
+            return HVACAction.IDLE
+
+        # No optimistic state — use real API data
+        appliance_state = _normalize_enum_value(
+            self._details.get(frigidaire.Detail.APPLIANCE_STATE)
+        )
+
+        if appliance_state in ["OFF", "DELAYED_START"]:
+            return HVACAction.OFF
+
+        mode = self.hvac_mode
+        if mode == HVACMode.COOL:
+            return HVACAction.COOLING
+        elif mode == HVACMode.AUTO:
+            return HVACAction.COOLING
+        elif mode == HVACMode.FAN_ONLY:
+            return HVACAction.FAN
+        elif mode == HVACMode.DRY:
+            return HVACAction.DRYING
+
+        return HVACAction.IDLE
 
     @property
     def target_temperature_step(self):
@@ -216,6 +277,9 @@ class FrigidaireClimate(ClimateEntity):
     @property
     def temperature_unit(self):
         """Return the unit of measurement which this thermostat uses."""
+        if not self._details:
+            return UnitOfTemperature.CELSIUS  # Default to Celsius if we don't have details yet
+        
         unit = _normalize_enum_value(self._details.get(
             frigidaire.Detail.TEMPERATURE_REPRESENTATION
         ))
@@ -225,87 +289,113 @@ class FrigidaireClimate(ClimateEntity):
     @property
     def swing_mode(self):
         """Return the swing setting."""
-        swing = _normalize_enum_value(self._details.get(
-            frigidaire.Detail.VERTICAL_SWING
-        ))
-
+        if self._is_optimistic() and self._optimistic_swing_mode is not None:
+            return self._optimistic_swing_mode
+        if not self._details:
+            return SWING_OFF
+        swing = _normalize_enum_value(self._details.get(frigidaire.Detail.VERTICAL_SWING))
         return FRIGIDAIRE_TO_HA_SWING[swing]
 
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
+        if self._is_optimistic() and self._optimistic_temperature is not None:
+            return self._optimistic_temperature
+        if not self._details:
+            return 0
         if self.temperature_unit == UnitOfTemperature.FAHRENHEIT:
             return self._details.get(frigidaire.Detail.TARGET_TEMPERATURE_F)
-        else:
-            return self._details.get(frigidaire.Detail.TARGET_TEMPERATURE_C)
+        return self._details.get(frigidaire.Detail.TARGET_TEMPERATURE_C)
         
     @property
     def preset_mode(self):
         """Return current preset mode."""
-        sleep = _normalize_enum_value(
-            self._details.get(frigidaire.Detail.SLEEP_MODE)
-        )
-        sleep_norm = _normalize_enum_value(sleep)
-        _LOGGER.debug("PRESET MODE: raw=%s, normalized=%s, mapped=%s", sleep, sleep_norm, FRIGIDAIRE_TO_HA_PRESET.get(sleep_norm))
-        return FRIGIDAIRE_TO_HA_PRESET[sleep_norm]
+        if self._is_optimistic() and self._optimistic_preset_mode is not None:
+            return self._optimistic_preset_mode
+        if not self._details:
+            return PRESET_NONE
+        sleep = _normalize_enum_value(self._details.get(frigidaire.Detail.SLEEP_MODE))
+        return FRIGIDAIRE_TO_HA_PRESET[sleep]
 
     @property
     def hvac_mode(self):
         """Return current operation i.e. heat, cool, idle."""
+        if self._is_optimistic() and self._optimistic_hvac_mode is not None:
+            return self._optimistic_hvac_mode
+        if not self._details:
+            return HVACMode.OFF
         appliance_state = _normalize_enum_value(
             self._details.get(frigidaire.Detail.APPLIANCE_STATE)
         )
-        
         if appliance_state in ["OFF", "DELAYED_START"]:
             return HVACMode.OFF
-    
-        frigidaire_mode = _normalize_enum_value(
-            self._details.get(frigidaire.Detail.MODE)
-        )
-    
+        frigidaire_mode = _normalize_enum_value(self._details.get(frigidaire.Detail.MODE))
         return FRIGIDAIRE_TO_HA_MODE[frigidaire_mode]
 
     @property
     def current_temperature(self):
         """Return the current temperature."""
+        if not self._details:
+            return 0
         if self.temperature_unit == UnitOfTemperature.FAHRENHEIT:
             return self._details.get(frigidaire.Detail.AMBIENT_TEMPERATURE_F)
-        else:
-            return self._details.get(frigidaire.Detail.AMBIENT_TEMPERATURE_C)
+        return self._details.get(frigidaire.Detail.AMBIENT_TEMPERATURE_C)
 
     @property
     def fan_mode(self):
         """Return the fan setting."""
+        if self._is_optimistic() and self._optimistic_fan_mode is not None:
+            return self._optimistic_fan_mode
+        if not self._details:
+            return FAN_OFF
         fan_speed = _normalize_enum_value(self._details.get(frigidaire.Detail.FAN_SPEED))
-
         if not fan_speed:
             return FAN_OFF
-
         return FRIGIDAIRE_TO_HA_FAN_SPEED[fan_speed]
 
     @property
     def min_temp(self):
         """Return the minimum temperature."""
-        if self.temperature_unit == UnitOfTemperature.FAHRENHEIT:
-            return 60
-
-        return 16
+        return 60 if self.temperature_unit == UnitOfTemperature.FAHRENHEIT else 16
 
     @property
     def max_temp(self):
-        """Return the maximum temperature."""
-        if self.temperature_unit == UnitOfTemperature.FAHRENHEIT:
-            return 90
-
-        return 32
+        return 90 if self.temperature_unit == UnitOfTemperature.FAHRENHEIT else 32
 
     @property
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
+        """Return the extra state attributes, check_filter, start_time and stop_time."""
+        if not self._details:
+            return None
         return {
             "check_filter": bool(
                 _normalize_enum_value(self._details.get(frigidaire.Detail.FILTER_STATE)) == "CHANGE"
             ),
+            "start_time": self._details.get(frigidaire.Detail.START_TIME),
+            "stop_time": self._details.get(frigidaire.Detail.STOP_TIME)
         }
+    
+    def _is_optimistic(self) -> bool:
+        """Return True if we are within the optimistic window."""
+        if self._optimistic_until is None:
+            return False
+        from datetime import datetime
+        return datetime.now().timestamp() < self._optimistic_until
+    
+
+    def _set_optimistic_window(self) -> None:
+        """Start the optimistic window."""
+        from datetime import datetime, timedelta
+        self._optimistic_until = (datetime.now() + timedelta(seconds=OPTIMISTIC_WINDOW)).timestamp()
+
+    def _clear_optimistic(self) -> None:
+        """Clear all optimistic overrides."""
+        self._optimistic_hvac_mode = None
+        self._optimistic_fan_mode = None
+        self._optimistic_preset_mode = None
+        self._optimistic_swing_mode = None
+        self._optimistic_temperature = None
+        self._optimistic_until = None
 
     def set_temperature(self, **kwargs):
         """Set new target temperature."""
@@ -314,137 +404,97 @@ class FrigidaireClimate(ClimateEntity):
             return
         temperature = int(temperature)
         temperature_unit = HA_TO_FRIGIDAIRE_UNIT[self.temperature_unit]
-
-        _LOGGER.debug("Setting temperature to int({}) {}".format(temperature, self.temperature_unit))
+        _LOGGER.debug("Setting temperature to %s %s", temperature, self.temperature_unit)
         self._client.execute_action(
-            self._appliance, frigidaire.Action.set_temperature(temperature, temperature_unit)
+            self._appliance,
+            frigidaire.Action.set_temperature(temperature, temperature_unit),
         )
+        self._optimistic_temperature = float(temperature)
+        self._set_optimistic_window()
+        self.schedule_update_ha_state(force_refresh=False)
 
     def set_fan_mode(self, fan_mode):
         """Set new target fan mode."""
-        # Guard against unexpected fan modes
         if fan_mode not in HA_TO_FRIGIDAIRE_FAN_MODE:
             return
-
-        action = frigidaire.Action.set_fan_speed(HA_TO_FRIGIDAIRE_FAN_MODE[fan_mode])
-        self._client.execute_action(self._appliance, action)
+        self._client.execute_action(
+            self._appliance,
+            frigidaire.Action.set_fan_speed(HA_TO_FRIGIDAIRE_FAN_MODE[fan_mode]),
+        )
+        self._optimistic_fan_mode = fan_mode
+        self._set_optimistic_window()
+        self.schedule_update_ha_state(force_refresh=False)
 
     def set_preset_mode(self, preset_mode) -> None:
         """Set new preset mode."""
-        if preset_mode == PRESET_SLEEP:
-            action = frigidaire.Action.set_sleep_mode(frigidaire.SleepMode.ON)
-        elif preset_mode == PRESET_NONE:
-            action = frigidaire.Action.set_sleep_mode(frigidaire.SleepMode.OFF)
-        else:
+        if preset_mode not in HA_TO_FRIGIDAIRE_PRESET:
             return
+        self._client.execute_action(
+            self._appliance,
+            frigidaire.Action.set_sleep_mode(HA_TO_FRIGIDAIRE_PRESET[preset_mode]),
+        )
+        self._optimistic_preset_mode = preset_mode
+        self._set_optimistic_window()
+        self.schedule_update_ha_state(force_refresh=False)
 
-        self._client.execute_action(self._appliance, action)
-
-    def set_swing_mode(self, preset_mode) -> None:
+    def set_swing_mode(self, swing_mode) -> None:
         """Set new swing mode."""
-        if preset_mode == SWING_VERTICAL:
-            action = frigidaire.Action.set_vertical_swing(frigidaire.VerticalSwing.ON)
-        elif preset_mode == SWING_OFF:
-            action = frigidaire.Action.set_vertical_swing(frigidaire.VerticalSwing.OFF)
-        else:
+        if swing_mode not in HA_TO_FRIGIDAIRE_SWING:
             return
-
-        self._client.execute_action(self._appliance, action)
+        self._client.execute_action(
+            self._appliance,
+            frigidaire.Action.set_vertical_swing(HA_TO_FRIGIDAIRE_SWING[swing_mode]),
+        )
+        self._optimistic_swing_mode = swing_mode
+        self._set_optimistic_window()
+        self.schedule_update_ha_state(force_refresh=False)
 
     def set_hvac_mode(self, hvac_mode):
         """Set new target operation mode."""
         _LOGGER.debug("Setting HVAC mode to %s", hvac_mode)
+
         if hvac_mode == HVACMode.OFF:
             self._client.execute_action(
                 self._appliance,
                 frigidaire.Action.set_mode(frigidaire.Mode.OFF),
             )
-            return
-
-        # Guard against unexpected hvac modes
-        if hvac_mode not in HA_TO_FRIGIDAIRE_HVAC_MODE:
-            return
-
-        # Turn on if not currently on.
-        if _normalize_enum_value(self._details.get(frigidaire.Detail.MODE)) == frigidaire.Mode.OFF:
-            self._client.execute_action(
-                self._appliance, frigidaire.Action.set_power(frigidaire.Power.ON)
-            )
-
-            # temperature reverts to default when the device is turned on
+        else:
+            if hvac_mode not in HA_TO_FRIGIDAIRE_HVAC_MODE:
+                return
+            if _normalize_enum_value(self._details.get(frigidaire.Detail.MODE)) == frigidaire.Mode.OFF:
+                self._client.execute_action(
+                    self._appliance,
+                    [
+                        frigidaire.Action.set_power(frigidaire.Power.ON),
+                        frigidaire.Action.set_temperature(int(self.target_temperature)),
+                    ],
+                )
             self._client.execute_action(
                 self._appliance,
-                frigidaire.Action.set_temperature(int(self.target_temperature))
+                frigidaire.Action.set_mode(HA_TO_FRIGIDAIRE_HVAC_MODE[hvac_mode]),
             )
 
-        self._client.execute_action(
-            self._appliance,
-            frigidaire.Action.set_mode(HA_TO_FRIGIDAIRE_HVAC_MODE[hvac_mode]),
-        )
+        self._optimistic_hvac_mode = hvac_mode
+        self._set_optimistic_window()
+        self.schedule_update_ha_state(force_refresh=False)
 
     def update(self):
         """Retrieve latest state and updates the details."""
         try:
             details = self._client.get_appliance_details(self._appliance)
-            _LOGGER.debug("Retrieved details for appliance %s: %s", self._appliance.appliance_id, details)
+            _LOGGER.debug(
+                "Retrieved details for appliance %s: %s",
+                self._appliance.appliance_id, details,
+            )
             self._details = details
         except frigidaire.FrigidaireException:
             if self.available:
                 _LOGGER.error("Failed to connect to Frigidaire servers")
             self._attr_available = False
         else:
-            # If we successfully retrieved details, the appliance is available
-            # Check that we have a valid applianceState
             appliance_state = self._details.get(frigidaire.Detail.APPLIANCE_STATE)
             self._attr_available = appliance_state is not None
-            
-            # Log detailed mapping information
-            try:
-                appliance_state = self._details.get(frigidaire.Detail.APPLIANCE_STATE)
-                _LOGGER.debug("APPLIANCE_STATE: raw=%s", appliance_state)
 
-                temp_repr = self._details.get(frigidaire.Detail.TEMPERATURE_REPRESENTATION)
-                temp_repr_norm = _normalize_enum_value(temp_repr)
-                _LOGGER.debug("TEMPERATURE_REPRESENTATION: raw=%s, normalized=%s, mapped=%s", 
-                              temp_repr,
-                              temp_repr_norm,
-                              FRIGIDAIRE_TO_HA_UNIT.get(temp_repr_norm))
-                
-                mode = self._details.get(frigidaire.Detail.MODE)
-                mode_norm = _normalize_enum_value(mode)
-                _LOGGER.debug("MODE: raw=%s, normalized=%s, mapped=%s",
-                              mode,
-                              mode_norm,
-                              FRIGIDAIRE_TO_HA_MODE.get(mode_norm))
-                
-                fan_speed = self._details.get(frigidaire.Detail.FAN_SPEED)
-                fan_speed_norm = _normalize_enum_value(fan_speed)
-                _LOGGER.debug("FAN_SPEED: raw=%s, normalized=%s, mapped=%s",
-                              fan_speed,
-                              fan_speed_norm,
-                              FRIGIDAIRE_TO_HA_FAN_SPEED.get(fan_speed_norm))
-                
-                target_temp_f = self._details.get(frigidaire.Detail.TARGET_TEMPERATURE_F)
-                target_temp_c = self._details.get(frigidaire.Detail.TARGET_TEMPERATURE_C)
-                _LOGGER.debug("TARGET_TEMPERATURE: F=%s, C=%s", target_temp_f, target_temp_c)
-                
-                ambient_temp_f = self._details.get(frigidaire.Detail.AMBIENT_TEMPERATURE_F)
-                ambient_temp_c = self._details.get(frigidaire.Detail.AMBIENT_TEMPERATURE_C)
-                _LOGGER.debug("AMBIENT_TEMPERATURE: F=%s, C=%s", ambient_temp_f, ambient_temp_c)
-                
-                filter_state = self._details.get(frigidaire.Detail.FILTER_STATE)
-                filter_state_norm = _normalize_enum_value(filter_state)
-                _LOGGER.debug("FILTER_STATE: raw=%s, normalized=%s, is_change=%s",
-                              filter_state, filter_state_norm, filter_state_norm == "CHANGE")
-                
-                sleep_mode = self._details.get(frigidaire.Detail.SLEEP_MODE)
-                sleep_mode_norm = _normalize_enum_value(sleep_mode)
-                _LOGGER.debug("SLEEP_MODE: raw=%s, normalized=%s, mapped=%s",
-                              sleep_mode, sleep_mode_norm, FRIGIDAIRE_TO_HA_PRESET.get(sleep_mode_norm))
-                
-                vertical_swing = self._details.get(frigidaire.Detail.VERTICAL_SWING)
-                vertical_swing_norm = _normalize_enum_value(vertical_swing)
-                _LOGGER.debug("VERTICAL_SWING: raw=%s, normalized=%s, mapped=%s",
-                              vertical_swing, vertical_swing_norm, FRIGIDAIRE_TO_HA_SWING.get(vertical_swing_norm))
-            except Exception as e:
-                _LOGGER.error("Error logging detail mappings: %s", e)
+            # Clear optimistic state once polling window expires
+            if not self._is_optimistic():
+                self._clear_optimistic()

--- a/custom_components/frigidaire/climate.py
+++ b/custom_components/frigidaire/climate.py
@@ -13,6 +13,10 @@ from homeassistant.components.climate.const import (
     FAN_LOW,
     FAN_MEDIUM,
     FAN_OFF,
+    PRESET_NONE,
+    PRESET_SLEEP,
+    SWING_OFF,
+    SWING_VERTICAL,
     HVACMode,
     ClimateEntityFeature,
 )
@@ -70,6 +74,16 @@ FRIGIDAIRE_TO_HA_MODE = {
     frigidaire.Mode.DRY: HVACMode.DRY,
 }
 
+FRIGIDAIRE_TO_HA_PRESET = {
+    frigidaire.SleepMode.OFF: PRESET_NONE,
+    frigidaire.SleepMode.ON: PRESET_SLEEP
+}
+
+FRIGIDAIRE_TO_HA_SWING = {
+    frigidaire.VerticalSwing.OFF: SWING_OFF,
+    frigidaire.VerticalSwing.ON: SWING_VERTICAL
+}
+
 FRIGIDAIRE_TO_HA_FAN_SPEED = {
     frigidaire.FanSpeed.AUTO: FAN_AUTO,
     frigidaire.FanSpeed.LOW: FAN_LOW,
@@ -87,6 +101,16 @@ HA_TO_FRIGIDAIRE_FAN_MODE = {
     FAN_LOW: frigidaire.FanSpeed.LOW,
     FAN_MEDIUM: frigidaire.FanSpeed.MEDIUM,
     FAN_HIGH: frigidaire.FanSpeed.HIGH,
+}
+
+HA_TO_FRIGIDAIRE_PRESET = {
+    PRESET_NONE: frigidaire.SleepMode.OFF,
+    PRESET_SLEEP: frigidaire.SleepMode.ON
+}
+
+HA_TO_FRIGIDAIRE_SWING = {
+    SWING_OFF: frigidaire.VerticalSwing.OFF,
+    SWING_VERTICAL: frigidaire.VerticalSwing.ON
 }
 
 HA_TO_FRIGIDAIRE_HVAC_MODE = {
@@ -119,13 +143,25 @@ class FrigidaireClimate(ClimateEntity):
         self._attr_supported_features = (ClimateEntityFeature.TARGET_TEMPERATURE |
                                          ClimateEntityFeature.FAN_MODE |
                                          ClimateEntityFeature.TURN_OFF |
-                                         ClimateEntityFeature.TURN_ON)
+                                         ClimateEntityFeature.TURN_ON |
+                                         ClimateEntityFeature.SWING_MODE |
+                                         ClimateEntityFeature.PRESET_MODE)
         self._attr_target_temperature_step = 1
 
         # Although we can access the Frigidaire API to get updates, they are
         # not reflected immediately after making a request. To improve the UX
         # around this, we set assume_state to True
         self._attr_assumed_state = True
+
+        self._attr_preset_modes = [
+            PRESET_NONE,
+            PRESET_SLEEP
+        ]
+
+        self._attr_swing_modes = [
+            SWING_OFF,
+            SWING_VERTICAL
+        ]
 
         self._attr_fan_modes = [
             FAN_AUTO,
@@ -185,6 +221,15 @@ class FrigidaireClimate(ClimateEntity):
         ))
 
         return FRIGIDAIRE_TO_HA_UNIT[unit]
+    
+    @property
+    def swing_mode(self):
+        """Return the swing setting."""
+        swing = _normalize_enum_value(self._details.get(
+            frigidaire.Detail.VERTICAL_SWING
+        ))
+
+        return FRIGIDAIRE_TO_HA_SWING[swing]
 
     @property
     def target_temperature(self):
@@ -193,12 +238,31 @@ class FrigidaireClimate(ClimateEntity):
             return self._details.get(frigidaire.Detail.TARGET_TEMPERATURE_F)
         else:
             return self._details.get(frigidaire.Detail.TARGET_TEMPERATURE_C)
+        
+    @property
+    def preset_mode(self):
+        """Return current preset mode."""
+        sleep = _normalize_enum_value(
+            self._details.get(frigidaire.Detail.SLEEP_MODE)
+        )
+        sleep_norm = _normalize_enum_value(sleep)
+        _LOGGER.debug("PRESET MODE: raw=%s, normalized=%s, mapped=%s", sleep, sleep_norm, FRIGIDAIRE_TO_HA_PRESET.get(sleep_norm))
+        return FRIGIDAIRE_TO_HA_PRESET[sleep_norm]
 
     @property
     def hvac_mode(self):
         """Return current operation i.e. heat, cool, idle."""
-        frigidaire_mode = _normalize_enum_value(self._details.get(frigidaire.Detail.MODE))
-
+        appliance_state = _normalize_enum_value(
+            self._details.get(frigidaire.Detail.APPLIANCE_STATE)
+        )
+        
+        if appliance_state in ["OFF", "DELAYED_START"]:
+            return HVACMode.OFF
+    
+        frigidaire_mode = _normalize_enum_value(
+            self._details.get(frigidaire.Detail.MODE)
+        )
+    
         return FRIGIDAIRE_TO_HA_MODE[frigidaire_mode]
 
     @property
@@ -265,11 +329,35 @@ class FrigidaireClimate(ClimateEntity):
         action = frigidaire.Action.set_fan_speed(HA_TO_FRIGIDAIRE_FAN_MODE[fan_mode])
         self._client.execute_action(self._appliance, action)
 
+    def set_preset_mode(self, preset_mode) -> None:
+        """Set new preset mode."""
+        if preset_mode == PRESET_SLEEP:
+            action = frigidaire.Action.set_sleep_mode(frigidaire.SleepMode.ON)
+        elif preset_mode == PRESET_NONE:
+            action = frigidaire.Action.set_sleep_mode(frigidaire.SleepMode.OFF)
+        else:
+            return
+
+        self._client.execute_action(self._appliance, action)
+
+    def set_swing_mode(self, preset_mode) -> None:
+        """Set new swing mode."""
+        if preset_mode == SWING_VERTICAL:
+            action = frigidaire.Action.set_vertical_swing(frigidaire.VerticalSwing.ON)
+        elif preset_mode == SWING_OFF:
+            action = frigidaire.Action.set_vertical_swing(frigidaire.VerticalSwing.OFF)
+        else:
+            return
+
+        self._client.execute_action(self._appliance, action)
+
     def set_hvac_mode(self, hvac_mode):
         """Set new target operation mode."""
+        _LOGGER.debug("Setting HVAC mode to %s", hvac_mode)
         if hvac_mode == HVACMode.OFF:
             self._client.execute_action(
-                self._appliance, frigidaire.Action.set_power(frigidaire.Power.OFF)
+                self._appliance,
+                frigidaire.Action.set_mode(frigidaire.Mode.OFF),
             )
             return
 
@@ -298,6 +386,7 @@ class FrigidaireClimate(ClimateEntity):
         """Retrieve latest state and updates the details."""
         try:
             details = self._client.get_appliance_details(self._appliance)
+            _LOGGER.debug("Retrieved details for appliance %s: %s", self._appliance.appliance_id, details)
             self._details = details
         except frigidaire.FrigidaireException:
             if self.available:
@@ -308,3 +397,54 @@ class FrigidaireClimate(ClimateEntity):
             # Check that we have a valid applianceState
             appliance_state = self._details.get(frigidaire.Detail.APPLIANCE_STATE)
             self._attr_available = appliance_state is not None
+            
+            # Log detailed mapping information
+            try:
+                appliance_state = self._details.get(frigidaire.Detail.APPLIANCE_STATE)
+                _LOGGER.debug("APPLIANCE_STATE: raw=%s", appliance_state)
+
+                temp_repr = self._details.get(frigidaire.Detail.TEMPERATURE_REPRESENTATION)
+                temp_repr_norm = _normalize_enum_value(temp_repr)
+                _LOGGER.debug("TEMPERATURE_REPRESENTATION: raw=%s, normalized=%s, mapped=%s", 
+                              temp_repr,
+                              temp_repr_norm,
+                              FRIGIDAIRE_TO_HA_UNIT.get(temp_repr_norm))
+                
+                mode = self._details.get(frigidaire.Detail.MODE)
+                mode_norm = _normalize_enum_value(mode)
+                _LOGGER.debug("MODE: raw=%s, normalized=%s, mapped=%s",
+                              mode,
+                              mode_norm,
+                              FRIGIDAIRE_TO_HA_MODE.get(mode_norm))
+                
+                fan_speed = self._details.get(frigidaire.Detail.FAN_SPEED)
+                fan_speed_norm = _normalize_enum_value(fan_speed)
+                _LOGGER.debug("FAN_SPEED: raw=%s, normalized=%s, mapped=%s",
+                              fan_speed,
+                              fan_speed_norm,
+                              FRIGIDAIRE_TO_HA_FAN_SPEED.get(fan_speed_norm))
+                
+                target_temp_f = self._details.get(frigidaire.Detail.TARGET_TEMPERATURE_F)
+                target_temp_c = self._details.get(frigidaire.Detail.TARGET_TEMPERATURE_C)
+                _LOGGER.debug("TARGET_TEMPERATURE: F=%s, C=%s", target_temp_f, target_temp_c)
+                
+                ambient_temp_f = self._details.get(frigidaire.Detail.AMBIENT_TEMPERATURE_F)
+                ambient_temp_c = self._details.get(frigidaire.Detail.AMBIENT_TEMPERATURE_C)
+                _LOGGER.debug("AMBIENT_TEMPERATURE: F=%s, C=%s", ambient_temp_f, ambient_temp_c)
+                
+                filter_state = self._details.get(frigidaire.Detail.FILTER_STATE)
+                filter_state_norm = _normalize_enum_value(filter_state)
+                _LOGGER.debug("FILTER_STATE: raw=%s, normalized=%s, is_change=%s",
+                              filter_state, filter_state_norm, filter_state_norm == "CHANGE")
+                
+                sleep_mode = self._details.get(frigidaire.Detail.SLEEP_MODE)
+                sleep_mode_norm = _normalize_enum_value(sleep_mode)
+                _LOGGER.debug("SLEEP_MODE: raw=%s, normalized=%s, mapped=%s",
+                              sleep_mode, sleep_mode_norm, FRIGIDAIRE_TO_HA_PRESET.get(sleep_mode_norm))
+                
+                vertical_swing = self._details.get(frigidaire.Detail.VERTICAL_SWING)
+                vertical_swing_norm = _normalize_enum_value(vertical_swing)
+                _LOGGER.debug("VERTICAL_SWING: raw=%s, normalized=%s, mapped=%s",
+                              vertical_swing, vertical_swing_norm, FRIGIDAIRE_TO_HA_SWING.get(vertical_swing_norm))
+            except Exception as e:
+                _LOGGER.error("Error logging detail mappings: %s", e)

--- a/custom_components/frigidaire/const.py
+++ b/custom_components/frigidaire/const.py
@@ -1,4 +1,4 @@
 """Constants for the frigidaire integration."""
 
 DOMAIN = "frigidaire"
-PLATFORMS = ["climate", "humidifier"]
+PLATFORMS = ["climate", "humidifier", "number"]

--- a/custom_components/frigidaire/humidifier.py
+++ b/custom_components/frigidaire/humidifier.py
@@ -131,6 +131,16 @@ class FrigidaireDehumidifier(HumidifierEntity):
     def unique_id(self):
         """Return unique ID based on Frigidaire ID."""
         return self._attr_unique_id
+    
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._appliance.appliance_id)},
+            "name": self._appliance.nickname,
+            "manufacturer": "Frigidaire",
+            "model": "AC",
+            "via_device": (DOMAIN, self._appliance.appliance_id),
+        }
 
     @property
     def name(self):

--- a/custom_components/frigidaire/manifest.json
+++ b/custom_components/frigidaire/manifest.json
@@ -2,13 +2,13 @@
   "domain": "frigidaire",
   "name": "frigidaire",
   "codeowners": [
-    "@kriodoxis"
+    "@bm1549"
   ],
   "config_flow": true,
   "dependencies": [],
-  "documentation": "https://github.com/kriodoxis/home-assistant-frigidaire",
+  "documentation": "https://github.com/bm1549/home-assistant-frigidaire",
   "iot_class": "cloud_polling",
-  "issue_tracker": "https://github.com/kriodoxis/home-assistant-frigidaire/issues",
+  "issue_tracker": "https://github.com/bm1549/home-assistant-frigidaire/issues",
   "requirements": [
     "frigidaire==0.18.44"
   ],

--- a/custom_components/frigidaire/manifest.json
+++ b/custom_components/frigidaire/manifest.json
@@ -2,13 +2,13 @@
   "domain": "frigidaire",
   "name": "frigidaire",
   "codeowners": [
-    "@bm1549"
+    "@kriodoxis"
   ],
   "config_flow": true,
   "dependencies": [],
-  "documentation": "https://github.com/bm1549/home-assistant-frigidaire",
+  "documentation": "https://github.com/kriodoxis/home-assistant-frigidaire",
   "iot_class": "cloud_polling",
-  "issue_tracker": "https://github.com/bm1549/home-assistant-frigidaire/issues",
+  "issue_tracker": "https://github.com/kriodoxis/home-assistant-frigidaire/issues",
   "requirements": [
     "frigidaire==0.18.29"
   ],

--- a/custom_components/frigidaire/number.py
+++ b/custom_components/frigidaire/number.py
@@ -1,0 +1,173 @@
+"""Number entities for Frigidaire timers (ON/OFF)."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+import logging
+from typing import Optional, Dict, List
+
+import frigidaire
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+STEP_SECONDS = 1800  # 30 minutes
+MAX_SECONDS = 86400  # 24 hours
+OPTIMISTIC_WINDOW = 5  # seconds to hold optimistic state after setting
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Frigidaire timer number entities."""
+    client = hass.data[DOMAIN][entry.entry_id]
+
+    appliances = await hass.async_add_executor_job(
+        client.get_appliances
+    )
+
+    entities: List[NumberEntity] = []
+
+    for appliance in appliances:
+        if appliance.destination != frigidaire.Destination.AIR_CONDITIONER:
+            continue
+
+        entities.append(FrigidaireTimerNumber(client, appliance, "off"))
+        entities.append(FrigidaireTimerNumber(client, appliance, "on"))
+
+    async_add_entities(entities, update_before_add=False)
+
+
+class FrigidaireTimerNumber(NumberEntity):
+    """Representation of AC timer (ON/OFF) in minutes."""
+
+    def __init__(self, client, appliance, timer_type: str):
+        self._client: frigidaire.Frigidaire = client
+        self._appliance: frigidaire.Appliance = appliance
+        self._details: Optional[Dict] = None
+
+        self._timer_type = timer_type  # "on" or "off"
+
+        self._optimistic_until: Optional[datetime] = None
+
+        suffix = "On Timer" if timer_type == "on" else "Off Timer"
+
+        # Entity attributes
+        self._attr_unique_id = f"{appliance.appliance_id}_timer_{timer_type}"
+        self._attr_name = f"{appliance.nickname} {suffix}"
+        self._attr_native_value = 0
+        self._attr_native_min_value = 0
+        self._attr_native_max_value = MAX_SECONDS
+        self._attr_native_step = STEP_SECONDS
+        self._attr_native_unit_of_measurement = "s"
+        self._attr_device_class = "duration"
+        self._attr_available = True
+        self._attr_assumed_state = True
+
+    @property
+    def assumed_state(self):
+        """Return True if unable to access real state of the entity."""
+        return self._attr_assumed_state
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._appliance.appliance_id)},
+            "name": self._appliance.nickname,
+            "manufacturer": "Frigidaire",
+            "model": "AC",
+            "via_device": (DOMAIN, self._appliance.appliance_id),
+        }
+    
+    @property
+    def extra_state_attributes(self) -> dict:
+        detail_key, attr_key = (
+            (frigidaire.Detail.STOP_TIME, "ac_off_timer")
+            if self._timer_type == "off"
+            else (frigidaire.Detail.START_TIME, "ac_on_timer")
+        )
+        seconds = (self._details or {}).get(detail_key) or 0
+        return {attr_key: seconds}
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set timer in minutes (rounded to nearest 30)."""
+        try:
+            seconds = int(round(value / STEP_SECONDS) * STEP_SECONDS)
+            seconds = max(0, min(MAX_SECONDS, seconds))
+
+            _LOGGER.debug("Setting %s timer for %s: requested=%s normalized=%s",
+                self._timer_type,
+                self._appliance.appliance_id,
+                value,
+                seconds,
+            )
+
+            if self._attr_native_value == seconds:
+                _LOGGER.debug("Timer unchanged, skipping API call")
+                return
+
+            action = (
+                frigidaire.Action.set_stop_time(seconds)
+                if self._timer_type == "off"
+                else frigidaire.Action.set_start_time(seconds)
+            )
+
+            await self.hass.async_add_executor_job(
+                self._client.execute_action, self._appliance, action
+            )
+
+            self._attr_native_value = seconds
+            self._optimistic_until = datetime.now() + timedelta(seconds=OPTIMISTIC_WINDOW)
+            self.async_write_ha_state()
+
+        except frigidaire.FrigidaireException:
+            _LOGGER.error("Failed to set %s timer for %s",
+                self._timer_type,
+                self._appliance.appliance_id,
+            )
+
+    def update(self):
+        """Retrieve latest state and update timer value."""
+        try:
+            details = self._client.get_appliance_details(self._appliance)
+            _LOGGER.debug("Retrieved details for appliance %s: %s", self._appliance.appliance_id, details)
+            self._details = details or {}
+            appliance_state = self._details.get(frigidaire.Detail.APPLIANCE_STATE)
+            if self._timer_type == "off":
+                active = appliance_state == frigidaire.ApplianceState.RUNNING
+                detail_key = frigidaire.Detail.STOP_TIME
+            else:
+                active = appliance_state in (
+                    frigidaire.ApplianceState.OFF,
+                    frigidaire.ApplianceState.DELAYED_START,
+                )
+                detail_key = frigidaire.Detail.START_TIME
+
+            self._attr_available = appliance_state is not None
+
+            if self._optimistic_until and datetime.now() < self._optimistic_until:
+                _LOGGER.debug(
+                    "Holding optimistic value for %s timer, %s seconds remaining",
+                    self._timer_type,
+                    (self._optimistic_until - datetime.now()).seconds,
+                )
+                return
+
+            self._optimistic_until = None
+            self._attr_native_value = self._details.get(detail_key) if active else 0
+
+        except frigidaire.FrigidaireException:
+            if self.available:
+                _LOGGER.error("Failed to update %s timer for %s",
+                    self._timer_type,
+                    self._appliance.appliance_id,
+                )
+            self._attr_available = False


### PR DESCRIPTION
feat(climate): Implement optimistic state and improved device integration

Major improvements:
- Add 5-second optimistic window for climate property changes (temperature, mode, fan, swing)
- Implement hvac_action property for proper state reporting
- Add device_info to climate and humidifier entities for Home Assistant device integration
- Fix parameter naming in set_swing_mode (preset_mode → swing_mode)
- Add start_time and stop_time to extra_state_attributes

feat(number): Add new platform for AC timer entities
- Create timer entities for ON/OFF time control
- Support 30-minute step increments with 24-hour maximum

fix: Correct HVACMode.AUTO mapping from Mode.ECO to Mode.AUTO