### PR TITLE
Handle SMART dehumidifier mode from API

### DIFF
--- a/custom_components/frigidaire/humidifier.py
+++ b/custom_components/frigidaire/humidifier.py
@@ -71,9 +71,15 @@ FRIGIDAIRE_TO_HA_MODE = {
     frigidaire.Mode.CONTINUOUS: MODE_BOOST,
     frigidaire.Mode.QUIET: MODE_SLEEP,
     frigidaire.Mode.AUTO: MODE_AUTO,
+    frigidaire.Mode.SMART: MODE_AUTO,
 }
 
-HA_TO_FRIGIDAIRE_MODE = {v: k for k, v in FRIGIDAIRE_TO_HA_MODE.items()}
+HA_TO_FRIGIDAIRE_MODE = {
+    MODE_NORMAL: frigidaire.Mode.DRY,
+    MODE_BOOST: frigidaire.Mode.CONTINUOUS,
+    MODE_SLEEP: frigidaire.Mode.QUIET,
+    MODE_AUTO: frigidaire.Mode.AUTO,
+}
 
 FRIGIDAIRE_TO_HA_FAN_MODE = {
     frigidaire.FanSpeed.LOW: FAN_LOW,

--- a/custom_components/frigidaire/manifest.json
+++ b/custom_components/frigidaire/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/bm1549/home-assistant-frigidaire/issues",
   "requirements": [
-    "frigidaire==0.18.45"
+    "frigidaire==0.18.46"
   ],
   "version": "0.1.19"
 }


### PR DESCRIPTION
## Summary

- Maps `Mode.SMART` → `MODE_AUTO` in `FRIGIDAIRE_TO_HA_MODE` so devices reporting SMART mode no longer crash with a `KeyError`
- Replaces the auto-derived `HA_TO_FRIGIDAIRE_MODE` inverse with an explicit dict — the bijection assumption broke once SMART and AUTO both map to `MODE_AUTO`, so both directions are now defined independently and clearly
- Bumps `frigidaire` to 0.18.46, which adds `Mode.SMART` (bm1549/frigidaire#71)

Closes bm1549/frigidaire#70.

## Test plan

- [ ] Deploy to HA with a dehumidifier that reports SMART mode — entity loads without error and displays mode as "auto"
- [ ] Selecting "auto" in HA UI still sends `AUTO` to the device (not SMART)
- [x] `ruff check` and `ruff format --check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)