### PR TITLE
Fixing issue with portable AC models not being reported to integration.

### DIFF
--- a/custom_components/frigidaire/climate.py
+++ b/custom_components/frigidaire/climate.py
@@ -197,6 +197,10 @@ class FrigidaireClimate(ClimateEntity):
         """Return current operation i.e. heat, cool, idle."""
         frigidaire_mode = _normalize_enum_value(self._details.get(frigidaire.Detail.MODE))
 
+        if frigidaire_mode not in FRIGIDAIRE_TO_HA_MODE:
+            _LOGGER.warning("Unsupported HVAC mode '%s' reported by device.", frigidaire_mode)
+            return None
+
         return FRIGIDAIRE_TO_HA_MODE[frigidaire_mode]
 
     @property
@@ -293,7 +297,10 @@ class FrigidaireClimate(ClimateEntity):
                 _LOGGER.error("Failed to connect to Frigidaire servers")
             self._attr_available = False
         else:
-            # If we successfully retrieved details, the appliance is available
-            # Check that we have a valid applianceState
+            # If we successfully retrieved details, the appliance is available.
+            # Prefer applianceState when present; fall back to checking for a
+            # reported mode, since some portable AC models (e.g. FHPW-series)
+            # omit applianceState from their API response.
             appliance_state = self._details.get(frigidaire.Detail.APPLIANCE_STATE)
-            self._attr_available = appliance_state is not None
+            mode = self._details.get(frigidaire.Detail.MODE)
+            self._attr_available = appliance_state is not None or mode is not None

--- a/custom_components/frigidaire/humidifier.py
+++ b/custom_components/frigidaire/humidifier.py
@@ -271,7 +271,10 @@ class FrigidaireDehumidifier(HumidifierEntity):
                 _LOGGER.error("Failed to connect to Frigidaire servers")
             self._attr_available = False
         else:
-            # If we successfully retrieved details, the appliance is available
-            # Check that we have a valid applianceState (running or off)
+            # If we successfully retrieved details, the appliance is available.
+            # Prefer applianceState when present; fall back to checking for a
+            # reported mode, since some models omit applianceState from their
+            # API response.
             appliance_state = self._details.get(frigidaire.Detail.APPLIANCE_STATE)
-            self._attr_available = appliance_state is not None
+            mode = self._details.get(frigidaire.Detail.MODE)
+            self._attr_available = appliance_state is not None or mode is not None


### PR DESCRIPTION
Fixes [#119](https://github.com/bm1549/home-assistant-frigidaire/issues/119) — FHPW122AC1 (and likely other FHPW-series portable ACs) shows as permanently unavailable and KeyError-crashes on unrecognized HVAC modes.

Root cause

The availability check introduced in 0.1.6 reads applianceState and marks the entity unavailable if that key is absent:

`self._attr_available = appliance_state is not None`
Portable AC models in the FHPW-series do not include applianceState in their API response, so the entity loads successfully but immediately shows as unavailable regardless of the device's actual state.

Separately, hvac_mode does a bare dict lookup against `FRIGIDAIRE_TO_HA_MODE` with no guard, which causes a KeyError crash if the device reports any mode not in the mapping. I encountered this with DRY after reverting to v0.1.5 (it fixed in 0.1.8), but any future undocumented mode would crash the same way.

Changes

`climate.py`

Availability check now falls back to checking mode is not None when applianceState is absent, since a device that is reporting a mode is clearly connected and operational.
hvac_mode property returns None and logs a warning instead of raising KeyError on an unrecognized mode, preventing the entity from crashing out entirely.

`humidifier.py`

Same availability fallback applied for consistency.