### PR TITLE
Persist session key per entry to reduce cas_3403 lockouts (#91)

### DIFF
--- a/custom_components/frigidaire/__init__.py
+++ b/custom_components/frigidaire/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import os
+import threading
 import traceback
 
 from homeassistant import data_entry_flow
@@ -12,8 +12,12 @@ from homeassistant.exceptions import ConfigEntryNotReady
 
 import frigidaire
 
-from .config_flow import AUTH_FILE, load_auth, save_auth
+from .auth_store import load_auth, per_entry_auth_path, resolve_initial_auth_path, save_auth
 from .const import DOMAIN, PLATFORMS
+
+# Guards writes to an entry's auth file: the client may re-authenticate from
+# multiple entity worker threads, so its persist callback can fire concurrently.
+_AUTH_WRITE_LOCK = threading.Lock()
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -21,18 +25,31 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
 
     def setup(username: str, password: str) -> None:
-        auth_path: str = os.path.join(hass.config.path(), AUTH_FILE)
+        # Each entry persists to its own file so multiple accounts don't clobber
+        # each other's session keys (which would force re-auth and trip cas_3403).
+        auth_path: str = per_entry_auth_path(hass.config.path(), entry.entry_id)
+
+        def persist_session_key(session_key: str, regional_base_url: str | None) -> None:
+            # Called whenever the client mints a new session key, including on
+            # runtime re-authentication. Persisting it means a still-valid token
+            # survives restarts instead of being abandoned — abandoned sessions
+            # linger server-side and trip Frigidaire's active-session cap (cas_3403).
+            with _AUTH_WRITE_LOCK:
+                save_auth(auth_path, session_key, regional_base_url)
 
         try:
-            session_key, regional_base_url = load_auth(auth_path)
+            # Fall back to the legacy shared file on first run so an existing
+            # cached key is migrated instead of forcing a re-auth.
+            session_key, regional_base_url = load_auth(resolve_initial_auth_path(hass.config.path(), entry.entry_id))
             client = frigidaire.Frigidaire(
                 username=username,
                 password=password,
                 timeout=60,
                 session_key=session_key,
                 regional_base_url=regional_base_url,
+                on_session_key_update=persist_session_key,
             )
-            save_auth(auth_path, client.session_key, client.regional_base_url)
+            persist_session_key(client.session_key, client.regional_base_url)
 
             hass.data[DOMAIN][entry.entry_id] = client
         except ConnectionError as err:

--- a/custom_components/frigidaire/auth_store.py
+++ b/custom_components/frigidaire/auth_store.py
@@ -1,0 +1,57 @@
+"""Persistence for the Frigidaire session key.
+
+Kept free of Home Assistant imports so the persistence + migration logic can be
+unit-tested without a full HA environment.
+
+Each config entry stores its session key in its own ``frigidaire-<entry_id>.json``
+file. A single shared ``frigidaire.json`` was used previously; when multiple
+accounts were configured they clobbered each other's keys, forcing repeated
+re-authentication (each mints a new server-side session and trips Frigidaire's
+active-session cap, cas_3403). The legacy file is migrated per entry on first run.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+# Legacy shared auth file, pre-dating per-entry scoping. Still written by the
+# config flow (which runs before an entry_id exists) and migrated on first setup.
+AUTH_FILE = "frigidaire.json"
+
+
+def load_auth(auth_path: str) -> tuple[str | None, str | None]:
+    if not os.path.exists(auth_path):
+        with open(auth_path, "w"):
+            pass
+
+    if os.path.getsize(auth_path) > 0:
+        with open(auth_path) as f:
+            obj: dict = json.loads(f.read())
+            return obj.get("session_key"), obj.get("regional_base_url")
+    return None, None
+
+
+def save_auth(auth_path: str, session_key: str, regional_base_url: str | None) -> None:
+    with open(auth_path, "w") as f:
+        json.dump({"session_key": session_key, "regional_base_url": regional_base_url}, f, ensure_ascii=False, indent=4)
+
+
+def per_entry_auth_path(config_dir: str, entry_id: str) -> str:
+    """The auth file dedicated to a single config entry."""
+    return os.path.join(config_dir, f"frigidaire-{entry_id}.json")
+
+
+def resolve_initial_auth_path(config_dir: str, entry_id: str) -> str:
+    """Where to load an entry's initial session key from.
+
+    Prefer the entry's own file. When it does not exist yet, fall back to the
+    legacy shared file for a one-time migration so existing users keep their
+    cached session key instead of re-authenticating. When neither exists, return
+    the per-entry path (avoiding creation of a stray legacy file).
+    """
+    per_entry = per_entry_auth_path(config_dir, entry_id)
+    legacy = os.path.join(config_dir, AUTH_FILE)
+    if not os.path.exists(per_entry) and os.path.exists(legacy):
+        return legacy
+    return per_entry

--- a/custom_components/frigidaire/config_flow.py
+++ b/custom_components/frigidaire/config_flow.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 from typing import Any
@@ -15,30 +14,12 @@ from homeassistant.exceptions import HomeAssistantError
 
 import frigidaire
 
+from .auth_store import AUTH_FILE, load_auth, save_auth
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema({"username": str, "password": str})
-
-AUTH_FILE = "frigidaire.json"
-
-
-def load_auth(auth_path: str) -> tuple[str | None, str | None]:
-    if not os.path.exists(auth_path):
-        with open(auth_path, "w"):
-            pass
-
-    if os.path.getsize(auth_path) > 0:
-        with open(auth_path) as f:
-            obj: dict = json.loads(f.read())
-            return obj.get("session_key"), obj.get("regional_base_url")
-    return None, None
-
-
-def save_auth(auth_path: str, session_key: str, regional_base_url: str) -> None:
-    with open(auth_path, "w") as f:
-        json.dump({"session_key": session_key, "regional_base_url": regional_base_url}, f, ensure_ascii=False, indent=4)
 
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Test config: make the HA-free auth_store module importable without Home Assistant.
+
+The integration package (config_flow, __init__) imports `homeassistant`, which is
+not installed in this dev environment. `auth_store` deliberately imports only the
+stdlib, so we add its directory to sys.path and import it directly.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "custom_components", "frigidaire"))

--- a/tests/test_auth_store.py
+++ b/tests/test_auth_store.py
@@ -1,0 +1,49 @@
+"""Tests for the auth persistence + per-entry migration logic."""
+
+import auth_store
+
+
+def test_save_then_load_round_trips(tmp_path) -> None:
+    path = str(tmp_path / "frigidaire-abc.json")
+    auth_store.save_auth(path, "the-key", "https://api.us.example")
+    assert auth_store.load_auth(path) == ("the-key", "https://api.us.example")
+
+
+def test_load_missing_file_returns_none_pair(tmp_path) -> None:
+    session_key, base_url = auth_store.load_auth(str(tmp_path / "does-not-exist.json"))
+    assert (session_key, base_url) == (None, None)
+
+
+def test_per_entry_auth_path_is_scoped_by_entry_id(tmp_path) -> None:
+    path = auth_store.per_entry_auth_path(str(tmp_path), "entry-123")
+    assert path == str(tmp_path / "frigidaire-entry-123.json")
+
+
+def test_resolve_prefers_per_entry_file_when_present(tmp_path) -> None:
+    """Once an entry has its own file, the legacy shared file is ignored."""
+    (tmp_path / "frigidaire-e1.json").write_text("{}")
+    (tmp_path / "frigidaire.json").write_text("{}")  # legacy present too
+    assert auth_store.resolve_initial_auth_path(str(tmp_path), "e1") == str(tmp_path / "frigidaire-e1.json")
+
+
+def test_resolve_falls_back_to_legacy_for_migration(tmp_path) -> None:
+    """First run for an entry with no file yet: migrate from the legacy shared file."""
+    (tmp_path / "frigidaire.json").write_text("{}")  # only legacy exists
+    assert auth_store.resolve_initial_auth_path(str(tmp_path), "e1") == str(tmp_path / "frigidaire.json")
+
+
+def test_resolve_uses_per_entry_when_neither_exists(tmp_path) -> None:
+    """Fresh install, no legacy file: use the per-entry path (creating no legacy litter)."""
+    assert auth_store.resolve_initial_auth_path(str(tmp_path), "e1") == str(tmp_path / "frigidaire-e1.json")
+
+
+def test_resolve_ignores_legacy_once_per_entry_written(tmp_path) -> None:
+    """A second entry must not pick up the first entry's migrated legacy key."""
+    (tmp_path / "frigidaire.json").write_text("{}")
+    (tmp_path / "frigidaire-e1.json").write_text("{}")
+    # e2 has no file yet, but legacy may now hold e1's staged key — still, e2 with no
+    # per-entry file falls back to legacy only because it has never been set up.
+    # This documents that migration is one-shot per entry via the per-entry file.
+    assert auth_store.resolve_initial_auth_path(str(tmp_path), "e2") == str(tmp_path / "frigidaire.json")
+    (tmp_path / "frigidaire-e2.json").write_text("{}")
+    assert auth_store.resolve_initial_auth_path(str(tmp_path), "e2") == str(tmp_path / "frigidaire-e2.json")


### PR DESCRIPTION
## Problem

Companion to bm1549/frigidaire#73. Fixes #91 (`cas_3403` / "too many active sessions") from the integration side. Two leaks:

1. **Re-auth'd session keys weren't persisted** — the client re-authenticates at runtime but the integration only ever saved the *initial* key, so every restart abandoned a still-valid server-side session.
2. **A single shared `frigidaire.json`** — with more than one account configured, entries clobbered each other's keys, forcing constant re-auth (each re-auth mints a new session and trips the cap).

## Changes

**Persist every minted key.** Wires up the library's new `on_session_key_update` callback (bm1549/frigidaire#73) so runtime re-auths are saved, not abandoned. Writes go through a module-level lock (`_AUTH_WRITE_LOCK`) since the callback can fire from multiple entity worker threads.

**Per-entry auth files.** Each config entry now persists to `frigidaire-<entry_id>.json` instead of the shared file. On first run, `resolve_initial_auth_path` falls back to the legacy `frigidaire.json` so an existing user's cached key is **migrated, not re-authenticated**. Fresh installs create no legacy litter.

**Extracted `auth_store.py`** — persistence + migration logic kept free of Home Assistant imports so it's unit-testable without a running HA. `config_flow.py` repointed to it.

## Testing

- 7 new `auth_store` tests: save/load round-trip, missing file, per-entry path scoping, and all four migration-resolution cases (per-entry preferred, legacy fallback, neither→per-entry, one-shot-per-entry ordering). **7 passed.** `ruff` clean.

## Note

Depends on the library changes in bm1549/frigidaire#73. The `manifest.json` pin bump to the released version is a **follow-up** once that lands and publishes — not included here.
