### PR TITLE
Fall back to waterTankFull when reporting bin_full

### DIFF
--- a/custom_components/frigidaire/humidifier.py
+++ b/custom_components/frigidaire/humidifier.py
@@ -185,6 +185,12 @@ class FrigidaireDehumidifier(HumidifierEntity):
             if water_bucket_level == 1:
                 bin_full = True
 
+        # Fallback to waterTankFull if neither alert nor waterBucketLevel is set
+        if not bin_full:
+            water_tank_full = _normalize_enum_value(self._details.get(frigidaire.Detail.WATER_TANK_FULL))
+            if water_tank_full in ("YES", True):
+                bin_full = True
+
         attrib["bin_full"] = bin_full
 
         return attrib


### PR DESCRIPTION
## Summary
- Some dehumidifier models (e.g. GHDD5035W1) never set the `BUCKET_FULL` alert or `waterBucketLevel`, so `bin_full` was stuck at `false` even when the physical tank-full indicator was lit.
- Adds a third fallback: check `Detail.WATER_TANK_FULL` (`waterTankFull == "YES"`) after the existing alert/`waterBucketLevel` checks.

Fixes #121

## Dependency
Resolved: bm1549/frigidaire#74 was merged and released as `frigidaire` 0.18.49, and `manifest.json`'s pin was bumped to that version in #131. This branch is rebased on top of that bump.

Still worth getting the issue reporter to confirm the fix actually flips `bin_full` on their device before/after emptying the tank — the field's "not full" value wasn't independently confirmed, only the "full" value from their posted API dump.

## Test plan
- [x] `ruff check` / `ruff format --check`
- [x] frigidaire#74 released to PyPI (0.18.49) and manifest.json pin bumped (#131)
- [ ] Reporter confirms `bin_full` now correctly reflects tank state on GHDD5035W1