### PR TITLE
Fix dehumidifier entity failing to load (_attr_available_modes)

### DIFF
--- a/custom_components/frigidaire/humidifier.py
+++ b/custom_components/frigidaire/humidifier.py
@@ -121,7 +121,7 @@ class FrigidaireDehumidifier(HumidifierEntity):
         #     FAN_HIGH,
         # ]
 
-        self._attr_modes = [
+        self._attr_available_modes = [
             MODE_NORMAL,
             MODE_BOOST,
             MODE_AUTO,

--- a/custom_components/frigidaire/manifest.json
+++ b/custom_components/frigidaire/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "frigidaire==0.18.49"
   ],
-  "version": "0.1.29"
+  "version": "0.1.30"
 }


### PR DESCRIPTION
## Problem

Since 0.1.27, no dehumidifier entity is created. The device shows up in HA but has no entity underneath it. Adding the entity throws:

```
Error adding entity None for domain humidifier with platform frigidaire
  File ".../homeassistant/components/humidifier/__init__.py", line 255, in available_modes
    return self._attr_available_modes
AttributeError: 'FrigidaireDehumidifier' object has no attribute '_attr_available_modes'
```

## Cause

The 0.1.27 refactor (#128) removed the `available_modes` property override:

```python
-    @property
-    def available_modes(self):
-        return self._attr_modes
```

but left the backing attribute named `self._attr_modes`. Home Assistant's base `HumidifierEntity.available_modes` reads `self._attr_available_modes`, which is never set, so adding the entity raises `AttributeError` and the entity is dropped. This affects every dehumidifier, which is why #121 shifted from "bin_full wrong" to "entity missing entirely".

## Fix

Rename `self._attr_modes` → `self._attr_available_modes` so the base class finds it. Also bumps the manifest to 0.1.30.

Fixes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XERhftTi14EkiB1P6BVdwf)_