### PR TITLE
Fix HVACMode.AUTO to engage the AC Eco mode instead of the unsupported Mode.AUTO

### DIFF
--- a/custom_components/frigidaire/climate.py
+++ b/custom_components/frigidaire/climate.py
@@ -89,8 +89,13 @@ HA_TO_FRIGIDAIRE_FAN_MODE = {
     FAN_HIGH: frigidaire.FanSpeed.HIGH,
 }
 
+# frigidaire.Mode.AUTO is a dehumidifier-only value (see frigidaire.Mode); this
+# platform only ever handles Destination.AIR_CONDITIONER appliances (see
+# async_setup_entry below), whose energy-saving mode is Mode.ECO. Sending
+# Mode.AUTO to an AC unit is silently ignored, so HVACMode.AUTO must map to
+# Mode.ECO here to round-trip with FRIGIDAIRE_TO_HA_MODE's ECO -> AUTO mapping.
 HA_TO_FRIGIDAIRE_HVAC_MODE = {
-    HVACMode.AUTO: frigidaire.Mode.AUTO,
+    HVACMode.AUTO: frigidaire.Mode.ECO,
     HVACMode.FAN_ONLY: frigidaire.Mode.FAN,
     HVACMode.COOL: frigidaire.Mode.COOL,
     HVACMode.OFF: frigidaire.Mode.OFF,


### PR DESCRIPTION
## Summary

Selecting **Auto** on a Frigidaire window/room air conditioner (e.g. `FHWW144TF1`) currently has no effect. This PR fixes the outbound HVAC-mode mapping so that `HVACMode.AUTO` engages the air conditioner's energy-saving **Eco** mode.

## Root cause

`HA_TO_FRIGIDAIRE_HVAC_MODE` translated Home Assistant's `HVACMode.AUTO` to `frigidaire.Mode.AUTO`:

```python
HA_TO_FRIGIDAIRE_HVAC_MODE = {
    HVACMode.AUTO: frigidaire.Mode.AUTO,
    ...
}
```

In the `frigidaire` library's `Mode` enum, `AUTO` is a **dehumidifier-only** value — it is listed under the dehumidifier modes alongside `CONTINUOUS`, `QUIET`, and `SMART`. The air-conditioner modes are `OFF`, `COOL`, `FAN` (`FANONLY`), and `ECO`. When `Mode.AUTO` is sent to an AC appliance, the device silently ignores it, so choosing "Auto" in HA does nothing.

## The fix

The inbound mapping already treats the device's Eco state as Auto:

```python
FRIGIDAIRE_TO_HA_MODE = {
    ...
    frigidaire.Mode.ECO: HVACMode.AUTO,
    frigidaire.Mode.AUTO: HVACMode.AUTO,
    ...
}
```

So `HVACMode.AUTO` is already how the Eco state is surfaced to the user. This PR makes the write path symmetric by mapping `HVACMode.AUTO -> frigidaire.Mode.ECO`. Selecting "Auto" now correctly turns on the AC's Eco mode, and the state round-trips consistently (Eco reads back as Auto).

## Changes

- `custom_components/frigidaire/climate.py`: map `HVACMode.AUTO` to `frigidaire.Mode.ECO` in `HA_TO_FRIGIDAIRE_HVAC_MODE`, with an explanatory comment.

## Testing

- `python -m py_compile custom_components/frigidaire/climate.py` passes.
- Verified on a `FHWW144TF1` window unit: before the change, selecting "Auto" left the unit in its prior mode; after the change, "Auto" engages Eco mode and the entity state reflects it.