### PR TITLE
Consolidate polling behind a per-appliance DataUpdateCoordinator

### DIFF
--- a/custom_components/frigidaire/__init__.py
+++ b/custom_components/frigidaire/__init__.py
@@ -65,9 +65,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 raise ConfigEntryNotReady("Rate limited by Frigidaire. Will retry automatically.") from err
             raise ConfigEntryNotReady(f"Frigidaire error during setup: {err}") from err
 
-    client, appliances = await hass.async_add_executor_job(
-        setup, entry.data["username"], entry.data["password"]
-    )
+    client, appliances = await hass.async_add_executor_job(setup, entry.data["username"], entry.data["password"])
 
     # One coordinator per appliance consolidates polling: every entity for a
     # device reads from a single shared fetch instead of hitting the API on its

--- a/custom_components/frigidaire/__init__.py
+++ b/custom_components/frigidaire/__init__.py
@@ -12,6 +12,7 @@ import frigidaire
 
 from .auth_store import load_auth, per_entry_auth_path, resolve_initial_auth_path, save_auth
 from .const import DOMAIN, PLATFORMS
+from .coordinator import FrigidaireApplianceCoordinator
 
 # Guards writes to an entry's auth file: the client may re-authenticate from
 # multiple entity worker threads, so its persist callback can fire concurrently.
@@ -22,7 +23,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up frigidaire from a config entry."""
     hass.data.setdefault(DOMAIN, {})
 
-    def setup(username: str, password: str) -> None:
+    def setup(username: str, password: str) -> tuple[frigidaire.Frigidaire, list[frigidaire.Appliance]]:
         # Each entry persists to its own file so multiple accounts don't clobber
         # each other's session keys (which would force re-auth and trip cas_3403).
         auth_path: str = per_entry_auth_path(hass.config.path(), entry.entry_id)
@@ -53,7 +54,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             # (climate, humidifier, number, switch) instead of each calling the
             # API separately.
             appliances = client.get_appliances()
-            hass.data[DOMAIN][entry.entry_id] = {"client": client, "appliances": appliances}
+            return client, appliances
         except ConnectionError as err:
             raise ConfigEntryNotReady("Cannot connect to Frigidaire") from err
         except frigidaire.FrigidaireException as err:
@@ -64,7 +65,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 raise ConfigEntryNotReady("Rate limited by Frigidaire. Will retry automatically.") from err
             raise ConfigEntryNotReady(f"Frigidaire error during setup: {err}") from err
 
-    await hass.async_add_executor_job(setup, entry.data["username"], entry.data["password"])
+    client, appliances = await hass.async_add_executor_job(
+        setup, entry.data["username"], entry.data["password"]
+    )
+
+    # One coordinator per appliance consolidates polling: every entity for a
+    # device reads from a single shared fetch instead of hitting the API on its
+    # own schedule. A first refresh here primes the data; individual failures are
+    # tolerated (the coordinator backs off and retries) so one flaky appliance
+    # doesn't block the whole entry from loading.
+    coordinators: dict[str, FrigidaireApplianceCoordinator] = {}
+    for appliance in appliances:
+        coordinator = FrigidaireApplianceCoordinator(hass, client, appliance)
+        await coordinator.async_refresh()
+        coordinators[appliance.appliance_id] = coordinator
+
+    hass.data[DOMAIN][entry.entry_id] = {
+        "client": client,
+        "appliances": appliances,
+        "coordinators": coordinators,
+    }
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/frigidaire/binary_sensor.py
+++ b/custom_components/frigidaire/binary_sensor.py
@@ -2,20 +2,18 @@
 
 from __future__ import annotations
 
-import logging
-
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 import frigidaire
 
 from .const import DOMAIN
+from .coordinator import FrigidaireApplianceCoordinator
 from .helpers import suggest_area
-
-_LOGGER = logging.getLogger(__name__)
 
 
 def _normalize(value):
@@ -26,7 +24,7 @@ def _normalize(value):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
     """Set up frigidaire binary sensor entities from a config entry."""
-    client = hass.data[DOMAIN][entry.entry_id]["client"]
+    coordinators: dict[str, FrigidaireApplianceCoordinator] = hass.data[DOMAIN][entry.entry_id]["coordinators"]
     appliances: list[frigidaire.Appliance] = hass.data[DOMAIN][entry.entry_id]["appliances"]
     options: dict[str, dict[str, bool]] = entry.options
 
@@ -34,33 +32,34 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         return
 
     entities = [
-        FrigidaireCheckFilterSensor(client, appliance, suggest_area(hass, appliance.nickname))
+        FrigidaireCheckFilterSensor(coordinators[appliance.appliance_id], suggest_area(hass, appliance.nickname))
         for appliance in appliances
         if options.get(appliance.appliance_id, {}).get("check_filter", False)
     ]
 
-    async_add_entities(entities, update_before_add=True)
+    async_add_entities(entities)
 
 
-class FrigidaireCheckFilterSensor(BinarySensorEntity):
+class FrigidaireCheckFilterSensor(CoordinatorEntity[FrigidaireApplianceCoordinator], BinarySensorEntity):
     """Binary sensor that is ON when the filter needs attention."""
 
     _attr_device_class = BinarySensorDeviceClass.PROBLEM
 
-    def __init__(
-        self, client: frigidaire.Frigidaire, appliance: frigidaire.Appliance, suggested_area: str | None = None
-    ) -> None:
-        self._client = client
-        self._appliance = appliance
-        self._details: dict = {}
-        self._attr_unique_id = f"{appliance.appliance_id}_check_filter"
+    def __init__(self, coordinator: FrigidaireApplianceCoordinator, suggested_area: str | None = None) -> None:
+        super().__init__(coordinator)
+        self._appliance = coordinator.appliance
+        self._attr_unique_id = f"{self._appliance.appliance_id}_check_filter"
         self._attr_name = "Check Filter"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, appliance.appliance_id)},
-            name=appliance.nickname,
+            identifiers={(DOMAIN, self._appliance.appliance_id)},
+            name=self._appliance.nickname,
             manufacturer="Frigidaire",
             suggested_area=suggested_area,
         )
+
+    @property
+    def _details(self) -> dict:
+        return self.coordinator.data or {}
 
     @property
     def is_on(self) -> bool | None:
@@ -68,12 +67,3 @@ class FrigidaireCheckFilterSensor(BinarySensorEntity):
         if filter_state is None:
             return None
         return filter_state != frigidaire.FilterState.GOOD
-
-    def update(self) -> None:
-        try:
-            self._details = self._client.get_appliance_details(self._appliance)
-            self._attr_available = True
-        except frigidaire.FrigidaireException:
-            if self.available:
-                _LOGGER.error("Failed to connect to Frigidaire servers")
-            self._attr_available = False

--- a/custom_components/frigidaire/climate.py
+++ b/custom_components/frigidaire/climate.py
@@ -23,13 +23,15 @@ from homeassistant.components.climate.const import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 import frigidaire
 
 from .const import DOMAIN
+from .coordinator import FrigidaireApplianceCoordinator
 from .helpers import suggest_area
 
 _LOGGER = logging.getLogger(__name__)
@@ -44,16 +46,13 @@ def _normalize_enum_value(value):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
     """Set up frigidaire from a config entry."""
-    client = hass.data[DOMAIN][entry.entry_id]["client"]
+    coordinators: dict[str, FrigidaireApplianceCoordinator] = hass.data[DOMAIN][entry.entry_id]["coordinators"]
     appliances: list[frigidaire.Appliance] = hass.data[DOMAIN][entry.entry_id]["appliances"]
 
     async_add_entities(
-        [
-            FrigidaireClimate(client, appliance, suggest_area(hass, appliance.nickname))
-            for appliance in appliances
-            if appliance.destination == frigidaire.Destination.AIR_CONDITIONER
-        ],
-        update_before_add=True,
+        FrigidaireClimate(coordinators[appliance.appliance_id], suggest_area(hass, appliance.nickname))
+        for appliance in appliances
+        if appliance.destination == frigidaire.Destination.AIR_CONDITIONER
     )
 
 
@@ -116,20 +115,18 @@ HA_TO_FRIGIDAIRE_PRESET = {
 OPTIMISTIC_WINDOW = 5  # seconds
 
 
-class FrigidaireClimate(ClimateEntity):
+class FrigidaireClimate(CoordinatorEntity[FrigidaireApplianceCoordinator], ClimateEntity):
     """Representation of a Frigidaire appliance."""
 
-    def __init__(self, client, appliance, suggested_area: str | None = None):
+    def __init__(self, coordinator: FrigidaireApplianceCoordinator, suggested_area: str | None = None):
         """Build FrigidaireClimate.
 
-        client: the client used to contact the frigidaire API
-        appliance: the basic information about the frigidaire appliance, used to contact
-            the API
+        coordinator: shared per-appliance coordinator that polls the frigidaire API
         """
 
-        self._client: frigidaire.Frigidaire = client
-        self._appliance: frigidaire.Appliance = appliance
-        self._details: dict = {}
+        super().__init__(coordinator)
+        self._client: frigidaire.Frigidaire = coordinator.client
+        self._appliance: frigidaire.Appliance = coordinator.appliance
 
         # Optimistic state — holds values for OPTIMISTIC_WINDOW seconds after a command
         self._optimistic_until: float = 0
@@ -174,6 +171,21 @@ class FrigidaireClimate(ClimateEntity):
             HVACMode.FAN_ONLY,
             HVACMode.DRY,
         ]
+
+    @property
+    def _details(self) -> dict:
+        return self.coordinator.data or {}
+
+    @property
+    def available(self) -> bool:
+        # Prefer applianceState when present; fall back to a reported mode, since
+        # some portable AC models (e.g. FHPW-series) omit applianceState from
+        # their API response.
+        if not super().available:
+            return False
+        appliance_state = self._details.get(frigidaire.Detail.APPLIANCE_STATE)
+        mode = self._details.get(frigidaire.Detail.MODE)
+        return appliance_state is not None or mode is not None
 
     def _set_optimistic_window(self) -> None:
         self._optimistic_until = time.monotonic() + OPTIMISTIC_WINDOW
@@ -298,7 +310,7 @@ class FrigidaireClimate(ClimateEntity):
         )
         self._optimistic_preset_mode = preset_mode
         self._set_optimistic_window()
-        self.schedule_update_ha_state(force_refresh=False)
+        self.schedule_update_ha_state(force_refresh=True)
 
     def set_swing_mode(self, swing_mode: str) -> None:
         if swing_mode not in HA_TO_FRIGIDAIRE_SWING:
@@ -308,7 +320,7 @@ class FrigidaireClimate(ClimateEntity):
         )
         self._optimistic_swing_mode = swing_mode
         self._set_optimistic_window()
-        self.schedule_update_ha_state(force_refresh=False)
+        self.schedule_update_ha_state(force_refresh=True)
 
     @property
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
@@ -328,7 +340,7 @@ class FrigidaireClimate(ClimateEntity):
         self._client.execute_action(self._appliance, frigidaire.Action.set_temperature(temperature, temperature_unit))
         self._optimistic_temperature = float(temperature)
         self._set_optimistic_window()
-        self.schedule_update_ha_state(force_refresh=False)
+        self.schedule_update_ha_state(force_refresh=True)
 
     def set_fan_mode(self, fan_mode):
         """Set new target fan mode."""
@@ -339,7 +351,7 @@ class FrigidaireClimate(ClimateEntity):
         )
         self._optimistic_fan_mode = fan_mode
         self._set_optimistic_window()
-        self.schedule_update_ha_state(force_refresh=False)
+        self.schedule_update_ha_state(force_refresh=True)
 
     def set_hvac_mode(self, hvac_mode):
         """Set new target operation mode."""
@@ -367,25 +379,11 @@ class FrigidaireClimate(ClimateEntity):
 
         self._optimistic_hvac_mode = hvac_mode
         self._set_optimistic_window()
-        self.schedule_update_ha_state(force_refresh=False)
+        self.schedule_update_ha_state(force_refresh=True)
 
-    def update(self):
-        """Retrieve latest state and updates the details."""
-        try:
-            details = self._client.get_appliance_details(self._appliance)
-            self._details = details
-        except frigidaire.FrigidaireException:
-            if self.available:
-                _LOGGER.error("Failed to connect to Frigidaire servers")
-            self._attr_available = False
-        else:
-            # If we successfully retrieved details, the appliance is available.
-            # Prefer applianceState when present; fall back to checking for a
-            # reported mode, since some portable AC models (e.g. FHPW-series)
-            # omit applianceState from their API response.
-            appliance_state = self._details.get(frigidaire.Detail.APPLIANCE_STATE)
-            mode = self._details.get(frigidaire.Detail.MODE)
-            self._attr_available = appliance_state is not None or mode is not None
-
-            if not self._is_optimistic():
-                self._clear_optimistic()
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Drop stale optimistic values once the command window has elapsed."""
+        if not self._is_optimistic():
+            self._clear_optimistic()
+        super()._handle_coordinator_update()

--- a/custom_components/frigidaire/coordinator.py
+++ b/custom_components/frigidaire/coordinator.py
@@ -44,9 +44,7 @@ class FrigidaireApplianceCoordinator(DataUpdateCoordinator[dict]):
     async def _async_update_data(self) -> dict:
         """Fetch the latest appliance details, backing off on repeated failures."""
         try:
-            details = await self.hass.async_add_executor_job(
-                self.client.get_appliance_details, self.appliance
-            )
+            details = await self.hass.async_add_executor_job(self.client.get_appliance_details, self.appliance)
         except (frigidaire.FrigidaireException, ConnectionError) as err:
             self._failure_count += 1
             # 30s, 60s, 120s, 240s … capped at MAX_INTERVAL.

--- a/custom_components/frigidaire/coordinator.py
+++ b/custom_components/frigidaire/coordinator.py
@@ -1,0 +1,61 @@
+"""DataUpdateCoordinator for the frigidaire integration."""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+import frigidaire
+
+_LOGGER = logging.getLogger(__name__)
+
+# A single shared poll per appliance replaces the old per-entity polling: a
+# device that exposes several entities (climate/switch/number/binary_sensor/…)
+# now hits the API once per cycle instead of once per entity. On failure we back
+# off exponentially up to MAX_INTERVAL so that when Frigidaire's auth servers are
+# flaky (upstream Gigya/token outages) we stop hammering them — repeated re-auth
+# is what trips Frigidaire's active-session cap (cas_3403).
+BASE_INTERVAL = timedelta(seconds=30)
+MAX_INTERVAL = timedelta(minutes=10)
+
+
+class FrigidaireApplianceCoordinator(DataUpdateCoordinator[dict]):
+    """Polls a single Frigidaire appliance and shares its details with every entity."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        client: frigidaire.Frigidaire,
+        appliance: frigidaire.Appliance,
+    ) -> None:
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"frigidaire {appliance.nickname}",
+            update_interval=BASE_INTERVAL,
+        )
+        self.client = client
+        self.appliance = appliance
+        self._failure_count = 0
+
+    async def _async_update_data(self) -> dict:
+        """Fetch the latest appliance details, backing off on repeated failures."""
+        try:
+            details = await self.hass.async_add_executor_job(
+                self.client.get_appliance_details, self.appliance
+            )
+        except (frigidaire.FrigidaireException, ConnectionError) as err:
+            self._failure_count += 1
+            # 30s, 60s, 120s, 240s … capped at MAX_INTERVAL.
+            backoff = BASE_INTERVAL * (2 ** (self._failure_count - 1))
+            self.update_interval = min(backoff, MAX_INTERVAL)
+            raise UpdateFailed(f"Error communicating with Frigidaire: {err}") from err
+
+        # Recovered — resume the normal polling cadence.
+        if self._failure_count:
+            self._failure_count = 0
+            self.update_interval = BASE_INTERVAL
+        return details

--- a/custom_components/frigidaire/humidifier.py
+++ b/custom_components/frigidaire/humidifier.py
@@ -21,10 +21,12 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 import frigidaire
 
 from .const import DOMAIN
+from .coordinator import FrigidaireApplianceCoordinator
 from .helpers import suggest_area
 
 _LOGGER = logging.getLogger(__name__)
@@ -51,16 +53,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         "set_fan_mode",
     )
 
-    client = hass.data[DOMAIN][entry.entry_id]["client"]
+    coordinators: dict[str, FrigidaireApplianceCoordinator] = hass.data[DOMAIN][entry.entry_id]["coordinators"]
     appliances: list[frigidaire.Appliance] = hass.data[DOMAIN][entry.entry_id]["appliances"]
 
     async_add_entities(
-        [
-            FrigidaireDehumidifier(client, appliance, suggest_area(hass, appliance.nickname))
-            for appliance in appliances
-            if appliance.destination == frigidaire.Destination.DEHUMIDIFIER
-        ],
-        update_before_add=True,
+        FrigidaireDehumidifier(coordinators[appliance.appliance_id], suggest_area(hass, appliance.nickname))
+        for appliance in appliances
+        if appliance.destination == frigidaire.Destination.DEHUMIDIFIER
     )
 
 
@@ -88,20 +87,18 @@ FRIGIDAIRE_TO_HA_FAN_MODE = {
 HA_TO_FRIGIDAIRE_FAN_MODE = {v: k for k, v in FRIGIDAIRE_TO_HA_FAN_MODE.items()}
 
 
-class FrigidaireDehumidifier(HumidifierEntity):
+class FrigidaireDehumidifier(CoordinatorEntity[FrigidaireApplianceCoordinator], HumidifierEntity):
     """Representation of a Frigidaire dehumidifier."""
 
-    def __init__(self, client, appliance, suggested_area: str | None = None):
+    def __init__(self, coordinator: FrigidaireApplianceCoordinator, suggested_area: str | None = None):
         """Build FrigidaireDehumidifier.
 
-        client: the client used to contact the frigidaire API
-        appliance: the basic information about the frigidaire appliance, used to contact
-            the API
+        coordinator: shared per-appliance coordinator that polls the frigidaire API
         """
 
-        self._client: frigidaire.Frigidaire = client
-        self._appliance: frigidaire.Appliance = appliance
-        self._details: dict = {}
+        super().__init__(coordinator)
+        self._client: frigidaire.Frigidaire = coordinator.client
+        self._appliance: frigidaire.Appliance = coordinator.appliance
 
         # Entity Class Attributes
         self._attr_unique_id = self._appliance.appliance_id
@@ -127,6 +124,20 @@ class FrigidaireDehumidifier(HumidifierEntity):
             MODE_AUTO,
             MODE_SLEEP,
         ]
+
+    @property
+    def _details(self) -> dict:
+        return self.coordinator.data or {}
+
+    @property
+    def available(self) -> bool:
+        # Prefer applianceState when present; fall back to a reported mode, since
+        # some models omit applianceState from their API response.
+        if not super().available:
+            return False
+        appliance_state = self._details.get(frigidaire.Detail.APPLIANCE_STATE)
+        mode = self._details.get(frigidaire.Detail.MODE)
+        return appliance_state is not None or mode is not None
 
     @property
     def is_on(self):
@@ -207,9 +218,11 @@ class FrigidaireDehumidifier(HumidifierEntity):
 
     def turn_on(self, **kwargs: Any) -> None:
         self._client.execute_action(self._appliance, frigidaire.Action.set_power(frigidaire.Power.ON))
+        self.schedule_update_ha_state(force_refresh=True)
 
     def turn_off(self, **kwargs: Any) -> None:
         self._client.execute_action(self._appliance, frigidaire.Action.set_power(frigidaire.Power.OFF))
+        self.schedule_update_ha_state(force_refresh=True)
 
     def set_humidity(self, humidity: int):
         """Set new target humidity."""
@@ -220,6 +233,7 @@ class FrigidaireDehumidifier(HumidifierEntity):
         # We have to be in dry mode to set a target humidity
         self.set_mode(MODE_NORMAL)
         self._client.execute_action(self._appliance, frigidaire.Action.set_humidity(humidity))
+        self.schedule_update_ha_state(force_refresh=True)
 
     def set_fan_mode(self, fan_mode):
         """Set new target fan mode."""
@@ -229,6 +243,7 @@ class FrigidaireDehumidifier(HumidifierEntity):
 
         action = frigidaire.Action.set_fan_speed(HA_TO_FRIGIDAIRE_FAN_MODE[fan_mode])
         self._client.execute_action(self._appliance, action)
+        self.schedule_update_ha_state(force_refresh=True)
 
     def set_mode(self, mode):
         """Set new target operation mode."""
@@ -242,21 +257,4 @@ class FrigidaireDehumidifier(HumidifierEntity):
             self.turn_on()
 
         self._client.execute_action(self._appliance, frigidaire.Action.set_mode(HA_TO_FRIGIDAIRE_MODE[mode]))
-
-    def update(self):
-        """Retrieve latest state and updates the details."""
-        try:
-            details = self._client.get_appliance_details(self._appliance)
-            self._details = details
-        except frigidaire.FrigidaireException:
-            if self.available:
-                _LOGGER.error("Failed to connect to Frigidaire servers")
-            self._attr_available = False
-        else:
-            # If we successfully retrieved details, the appliance is available.
-            # Prefer applianceState when present; fall back to checking for a
-            # reported mode, since some models omit applianceState from their
-            # API response.
-            appliance_state = self._details.get(frigidaire.Detail.APPLIANCE_STATE)
-            mode = self._details.get(frigidaire.Detail.MODE)
-            self._attr_available = appliance_state is not None or mode is not None
+        self.schedule_update_ha_state(force_refresh=True)

--- a/custom_components/frigidaire/number.py
+++ b/custom_components/frigidaire/number.py
@@ -2,22 +2,21 @@
 
 from __future__ import annotations
 
-import logging
 import time
 
 from homeassistant.components.number import NumberDeviceClass, NumberEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTime
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 import frigidaire
 
 from .const import DOMAIN
+from .coordinator import FrigidaireApplianceCoordinator
 from .helpers import suggest_area
-
-_LOGGER = logging.getLogger(__name__)
 
 
 def _normalize(value):
@@ -33,38 +32,37 @@ OPTIMISTIC_WINDOW = 5  # seconds to hold optimistic state after a command
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
     """Set up Frigidaire timer number entities."""
-    client = hass.data[DOMAIN][entry.entry_id]["client"]
+    coordinators: dict[str, FrigidaireApplianceCoordinator] = hass.data[DOMAIN][entry.entry_id]["coordinators"]
     appliances: list[frigidaire.Appliance] = hass.data[DOMAIN][entry.entry_id]["appliances"]
 
     entities = [
-        FrigidaireTimerNumber(client, appliance, timer_type, suggest_area(hass, appliance.nickname))
+        FrigidaireTimerNumber(coordinators[appliance.appliance_id], timer_type, suggest_area(hass, appliance.nickname))
         for appliance in appliances
         if appliance.destination == frigidaire.Destination.AIR_CONDITIONER
         for timer_type in ("on", "off")
     ]
 
-    async_add_entities(entities, update_before_add=True)
+    async_add_entities(entities)
 
 
-class FrigidaireTimerNumber(NumberEntity):
+class FrigidaireTimerNumber(CoordinatorEntity[FrigidaireApplianceCoordinator], NumberEntity):
     """AC ON or OFF timer, expressed in seconds with 30-minute steps."""
 
     def __init__(
         self,
-        client: frigidaire.Frigidaire,
-        appliance: frigidaire.Appliance,
+        coordinator: FrigidaireApplianceCoordinator,
         timer_type: str,
         suggested_area: str | None = None,
     ) -> None:
-        self._client = client
-        self._appliance = appliance
+        super().__init__(coordinator)
+        self._client = coordinator.client
+        self._appliance = coordinator.appliance
         self._timer_type = timer_type  # "on" or "off"
-        self._details: dict = {}
         self._optimistic_until: float = 0
         self._optimistic_value: float | None = None
 
         suffix = "On Timer" if timer_type == "on" else "Off Timer"
-        self._attr_unique_id = f"{appliance.appliance_id}_timer_{timer_type}"
+        self._attr_unique_id = f"{self._appliance.appliance_id}_timer_{timer_type}"
         self._attr_name = suffix
         self._attr_native_min_value = 0
         self._attr_native_max_value = MAX_SECONDS
@@ -72,11 +70,15 @@ class FrigidaireTimerNumber(NumberEntity):
         self._attr_native_unit_of_measurement = UnitOfTime.SECONDS
         self._attr_device_class = NumberDeviceClass.DURATION
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, appliance.appliance_id)},
-            name=appliance.nickname,
+            identifiers={(DOMAIN, self._appliance.appliance_id)},
+            name=self._appliance.nickname,
             manufacturer="Frigidaire",
             suggested_area=suggested_area,
         )
+
+    @property
+    def _details(self) -> dict:
+        return self.coordinator.data or {}
 
     @property
     def native_value(self) -> float:
@@ -105,15 +107,11 @@ class FrigidaireTimerNumber(NumberEntity):
         self._client.execute_action(self._appliance, action)
         self._optimistic_value = float(seconds)
         self._optimistic_until = time.monotonic() + OPTIMISTIC_WINDOW
+        self.schedule_update_ha_state(force_refresh=True)
 
-    def update(self) -> None:
-        try:
-            self._details = self._client.get_appliance_details(self._appliance)
-            self._attr_available = True
-        except frigidaire.FrigidaireException:
-            if self.available:
-                _LOGGER.error("Failed to connect to Frigidaire servers")
-            self._attr_available = False
-        else:
-            if time.monotonic() >= self._optimistic_until:
-                self._optimistic_value = None
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Clear stale optimistic state once the real value has settled."""
+        if time.monotonic() >= self._optimistic_until:
+            self._optimistic_value = None
+        super()._handle_coordinator_update()

--- a/custom_components/frigidaire/switch.py
+++ b/custom_components/frigidaire/switch.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 from typing import Any
 
@@ -11,14 +10,14 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 import frigidaire
 from frigidaire import Component, Detail, Setting
 
 from .const import DOMAIN
+from .coordinator import FrigidaireApplianceCoordinator
 from .helpers import suggest_area
-
-_LOGGER = logging.getLogger(__name__)
 
 
 def _normalize(value):
@@ -79,7 +78,7 @@ SWITCH_DESCRIPTIONS: dict[str, SwitchDescription] = {
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
     """Set up frigidaire switch entities from a config entry."""
-    client = hass.data[DOMAIN][entry.entry_id]["client"]
+    coordinators: dict[str, FrigidaireApplianceCoordinator] = hass.data[DOMAIN][entry.entry_id]["coordinators"]
     appliances: list[frigidaire.Appliance] = hass.data[DOMAIN][entry.entry_id]["appliances"]
     # options is keyed by appliance_id -> {switch_key: bool}
     options: dict[str, dict[str, bool]] = entry.options
@@ -88,39 +87,44 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         return
 
     entities = [
-        FrigidaireSwitch(client, appliance, SWITCH_DESCRIPTIONS[key], suggest_area(hass, appliance.nickname))
+        FrigidaireSwitch(
+            coordinators[appliance.appliance_id], SWITCH_DESCRIPTIONS[key], suggest_area(hass, appliance.nickname)
+        )
         for appliance in appliances
         for key, enabled in options.get(appliance.appliance_id, {}).items()
         if enabled and key in SWITCH_DESCRIPTIONS
     ]
 
-    async_add_entities(entities, update_before_add=True)
+    async_add_entities(entities)
 
 
-class FrigidaireSwitch(SwitchEntity):
+class FrigidaireSwitch(CoordinatorEntity[FrigidaireApplianceCoordinator], SwitchEntity):
     """A switch for a single Frigidaire boolean setting."""
 
     def __init__(
         self,
-        client: frigidaire.Frigidaire,
-        appliance: frigidaire.Appliance,
+        coordinator: FrigidaireApplianceCoordinator,
         desc: SwitchDescription,
         suggested_area: str | None = None,
     ) -> None:
-        self._client = client
-        self._appliance = appliance
+        super().__init__(coordinator)
+        self._client = coordinator.client
+        self._appliance = coordinator.appliance
         self._desc = desc
-        self._details: dict = {}
-        self._attr_unique_id = f"{appliance.appliance_id}_{desc.key}"
+        self._attr_unique_id = f"{self._appliance.appliance_id}_{desc.key}"
         self._attr_name = desc.name
         self._attr_device_class = desc.device_class
         self._attr_icon = desc.icon
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, appliance.appliance_id)},
-            name=appliance.nickname,
+            identifiers={(DOMAIN, self._appliance.appliance_id)},
+            name=self._appliance.nickname,
             manufacturer="Frigidaire",
             suggested_area=suggested_area,
         )
+
+    @property
+    def _details(self) -> dict:
+        return self.coordinator.data or {}
 
     @property
     def is_on(self) -> bool | None:
@@ -137,15 +141,8 @@ class FrigidaireSwitch(SwitchEntity):
 
     def turn_on(self, **kwargs: Any) -> None:
         self._client.execute_action(self._appliance, self._desc.make_action(True))
+        self.schedule_update_ha_state(force_refresh=True)
 
     def turn_off(self, **kwargs: Any) -> None:
         self._client.execute_action(self._appliance, self._desc.make_action(False))
-
-    def update(self) -> None:
-        try:
-            self._details = self._client.get_appliance_details(self._appliance)
-            self._attr_available = True
-        except frigidaire.FrigidaireException:
-            if self.available:
-                _LOGGER.error("Failed to connect to Frigidaire servers")
-            self._attr_available = False
+        self.schedule_update_ha_state(force_refresh=True)


### PR DESCRIPTION
Every entity (climate, humidifier, switch, number, binary_sensor)
previously polled get_appliance_details independently on Home
Assistant's 30s entity cycle, so a single device with several entities
hit the Frigidaire API N times per cycle. When Frigidaire's upstream
auth (Gigya/token) gets flaky, each of those calls can trigger a
re-authentication, multiplying auth pressure and tripping the
active-session cap (cas_3403) — which is what drove the hundreds of
failed-auth log entries reported in #136.

Introduce FrigidaireApplianceCoordinator: one shared poll per appliance
feeds all of its entities, cutting per-appliance API traffic to a single
request per cycle. On failure the coordinator backs off exponentially
(30s → 10min cap) instead of re-hammering the API, and resumes the
normal cadence once a poll succeeds.

Entities become CoordinatorEntity and read from coordinator.data;
optimistic state (climate/number) is preserved and cleared via
_handle_coordinator_update. Commands request a debounced coordinator
refresh so state still updates promptly after user actions.

This can't prevent an upstream outage, but it substantially reduces the
request volume and re-auth churn that turns one into a flood.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017ZVuXEoARAyrSU5hUcVxXt