### PR TITLE
Fix hvac_mode not reflecting OFF when appliance is powered off via ap…

### DIFF
--- a/custom_components/frigidaire/climate.py
+++ b/custom_components/frigidaire/climate.py
@@ -396,7 +396,9 @@ class FrigidaireClimate(CoordinatorEntity[FrigidaireApplianceCoordinator], Clima
         else:
             if hvac_mode not in HA_TO_FRIGIDAIRE_HVAC_MODE:
                 return
-            if _normalize_enum_value(self._details.get(frigidaire.Detail.MODE)) == frigidaire.Mode.OFF:
+            appliance_state = _normalize_enum_value(self._details.get(frigidaire.Detail.APPLIANCE_STATE))
+            frigidaire_mode = _normalize_enum_value(self._details.get(frigidaire.Detail.MODE))
+            if appliance_state == frigidaire.ApplianceState.OFF or frigidaire_mode == frigidaire.Mode.OFF:
                 self._client.execute_action(self._appliance, frigidaire.Action.set_power(frigidaire.Power.ON))
                 # temperature reverts to default when the device is turned on
                 current_temp = self.target_temperature

--- a/custom_components/frigidaire/climate.py
+++ b/custom_components/frigidaire/climate.py
@@ -249,6 +249,9 @@ class FrigidaireClimate(CoordinatorEntity[FrigidaireApplianceCoordinator], Clima
         """Return current operation i.e. heat, cool, idle."""
         if self._is_optimistic() and self._optimistic_hvac_mode is not None:
             return self._optimistic_hvac_mode
+        appliance_state = _normalize_enum_value(self._details.get(frigidaire.Detail.APPLIANCE_STATE))
+        if appliance_state == frigidaire.ApplianceState.OFF:
+            return HVACMode.OFF
         frigidaire_mode = _normalize_enum_value(self._details.get(frigidaire.Detail.MODE))
 
         if frigidaire_mode not in FRIGIDAIRE_TO_HA_MODE:


### PR DESCRIPTION
# Fix hvac_mode not reflecting OFF when appliance is powered off via app/remote

## Problem

On at least one Frigidaire portable/window AC model, `hvac_mode` never
reports `off`, even when the physical unit has been powered off via the
Frigidaire app or the IR remote. The climate entity's `state` stays stuck
on the last-used mode (e.g. `cool`) indefinitely, while `hvac_action`
correctly toggles between `idle`/`cooling` — creating a confusing
dashboard where the AC appears to be running when it's actually off.

**Affected device:** Frigidaire Gallery GHWW105TE1 (10,000 BTU inverter
window AC, service model number GHWW105TE100)

## Root cause

`hvac_mode` (climate.py) derives HA's `state` solely from
`frigidaire.Detail.MODE`:

```python
frigidaire_mode = _normalize_enum_value(self._details.get(frigidaire.Detail.MODE))
...
return FRIGIDAIRE_TO_HA_MODE[frigidaire_mode]
```

On this device, the cloud API keeps `MODE` set to `COOL` even after the
unit is powered off — it doesn't reset to `MODE: OFF`. Power state is
instead reflected separately via `Detail.APPLIANCE_STATE`
(`OFF` / `RUNNING` / `DELAYED_START`), which `hvac_action` already reads,
but `hvac_mode` never checks.

### Reproduction

1. Turn AC on via app or remote, mode = Cool.
2. Turn AC off via app or remote.
3. Query `climate.<entity>` state via `/api/states`:

   **Before fix**, after powering off:
   ```json
   {"state": "cool", "attributes": {"hvac_action": "idle", ...}}
   ```

   **After fix**, same physical state:
   ```json
   {"state": "off", "attributes": {"hvac_action": "off", ...}}
   ```

## Fix

Check `Detail.APPLIANCE_STATE` first in `hvac_mode`, mirroring the pattern
already used in `hvac_action`, and short-circuit to `HVACMode.OFF` when
the appliance reports `ApplianceState.OFF`:

```python
@property
def hvac_mode(self):
    """Return current operation i.e. heat, cool, idle."""
    if self._is_optimistic() and self._optimistic_hvac_mode is not None:
        return self._optimistic_hvac_mode
    appliance_state = _normalize_enum_value(self._details.get(frigidaire.Detail.APPLIANCE_STATE))
    if appliance_state == frigidaire.ApplianceState.OFF:
        return HVACMode.OFF
    frigidaire_mode = _normalize_enum_value(self._details.get(frigidaire.Detail.MODE))
    if frigidaire_mode not in FRIGIDAIRE_TO_HA_MODE:
        _LOGGER.warning("Unsupported HVAC mode '%s' reported by device.", frigidaire_mode)
        return None
    return FRIGIDAIRE_TO_HA_MODE[frigidaire_mode]
```

## Testing

Verified on a Frigidaire Gallery GHWW105TE1 window AC (service model
GHWW105TE100), frigidaire lib `0.18.49`, integration `0.1.31`, Home
Assistant Core `2026.6.4`. Confirmed via `/api/states/climate.<entity>`
before and after the change, using both the physical remote and the
Frigidaire app to power the unit off, with consistent results across
both control methods.

## Notes

- Not able to test against other Frigidaire product lines
  (dehumidifiers, other AC models) — would appreciate confirmation this
  doesn't regress `DELAYED_START` handling or dehumidifier behavior for
  maintainers/users with those devices.