### PR TITLE
Add opt-in compressor activity estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,26 @@ During setup — or at any time via **Configure** — you can enable additional 
 | Child Lock | Switch | Locks the physical controls on the unit |
 | Check Filter | Problem binary sensor | On for `CLEAN`, `CHANGE`, or `BUY`; exposes `filter_state` for notification automations |
 | Filter Runtime | Duration sensor | Cumulative filter runtime reported by the appliance in native seconds; Home Assistant handles display-unit conversion |
+| Compressor Estimate | Running binary sensor | Opt-in temperature-based estimate for air conditioners; also refines `hvac_action` while enabled |
 
 Each device is configured independently, so a home with both an AC and a dehumidifier can have different entities enabled for each.
 Filter runtime and the raw diagnostic attributes reuse the appliance platform's normal cloud response and do not add API polling.
+
+### Optional Compressor Estimate
+
+The Frigidaire API does not expose physical compressor telemetry. For air conditioners, **Enable compressor estimate**
+adds a diagnostic binary sensor that estimates compressor activity from operating mode, ambient temperature, and target
+temperature. It does not use `fanSpeedState`, which can retain its last value while the appliance is off.
+
+The option is disabled by default. While disabled, `hvac_action` retains the integration's standard behavior. While enabled,
+the same coordinator-owned estimate changes `hvac_action` from cooling or drying to idle after the configured temperature
+deadband and off delay are satisfied. Above the upper deadband boundary the estimate is running, below the lower boundary
+the off-delay timer runs, and between the boundaries the previous estimate is retained. It reuses the normal coordinator
+response and does not add cloud polling.
+
+If a standalone threshold signal is sufficient and changing `hvac_action` is not needed, Home Assistant's Threshold helper
+and a template binary sensor with `delay_off` can implement that externally instead. Helpers create separate entities; they
+cannot override the Frigidaire climate entity's own `hvac_action` property.
 
 ## Installing
 

--- a/custom_components/frigidaire/__init__.py
+++ b/custom_components/frigidaire/__init__.py
@@ -74,7 +74,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # doesn't block the whole entry from loading.
     coordinators: dict[str, FrigidaireApplianceCoordinator] = {}
     for appliance in appliances:
-        coordinator = FrigidaireApplianceCoordinator(hass, client, appliance)
+        coordinator = FrigidaireApplianceCoordinator(
+            hass,
+            client,
+            appliance,
+            entry.options.get(appliance.appliance_id, {}),
+        )
         await coordinator.async_refresh()
         coordinators[appliance.appliance_id] = coordinator
 

--- a/custom_components/frigidaire/binary_sensor.py
+++ b/custom_components/frigidaire/binary_sensor.py
@@ -17,6 +17,7 @@ import frigidaire
 
 from .const import (
     CONF_CHECK_FILTER_SENSOR,
+    CONF_COMPRESSOR_ESTIMATE,
     DOMAIN,
 )
 from .coordinator import FrigidaireApplianceCoordinator
@@ -37,6 +38,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         FrigidaireCheckFilterSensor(coordinators[appliance.appliance_id], suggest_area(hass, appliance.nickname))
         for appliance in appliances
         if options.get(appliance.appliance_id, {}).get(CONF_CHECK_FILTER_SENSOR, False)
+    ]
+    entities += [
+        FrigidaireCompressorEstimateSensor(coordinators[appliance.appliance_id], suggest_area(hass, appliance.nickname))
+        for appliance in appliances
+        if appliance.destination == frigidaire.Destination.AIR_CONDITIONER
+        and options.get(appliance.appliance_id, {}).get(CONF_COMPRESSOR_ESTIMATE, False)
     ]
 
     async_add_entities(entities)
@@ -80,3 +87,30 @@ class FrigidaireCheckFilterSensor(CoordinatorEntity[FrigidaireApplianceCoordinat
     @property
     def is_on(self) -> bool | None:
         return filter_needs_attention(self._details.get(frigidaire.Detail.FILTER_STATE))
+
+
+class FrigidaireCompressorEstimateSensor(CoordinatorEntity[FrigidaireApplianceCoordinator], BinarySensorEntity):
+    """Expose the coordinator's opt-in compressor estimate."""
+
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: FrigidaireApplianceCoordinator, suggested_area: str | None = None) -> None:
+        super().__init__(coordinator)
+        self._appliance = coordinator.appliance
+        self._attr_unique_id = f"{self._appliance.appliance_id}_compressor"
+        self._attr_name = "Compressor Estimate"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._appliance.appliance_id)},
+            name=self._appliance.nickname,
+            manufacturer="Frigidaire",
+            suggested_area=suggested_area,
+        )
+
+    @property
+    def available(self) -> bool:
+        return super().available and self.coordinator.compressor_running is not None
+
+    @property
+    def is_on(self) -> bool | None:
+        return self.coordinator.compressor_running

--- a/custom_components/frigidaire/climate.py
+++ b/custom_components/frigidaire/climate.py
@@ -283,6 +283,8 @@ class FrigidaireClimate(CoordinatorEntity[FrigidaireApplianceCoordinator], Clima
         # collapsing everything to COOLING.
         if mode == HVACMode.FAN_ONLY:
             return HVACAction.FAN
+        if self.coordinator.compressor_estimation_enabled and self.coordinator.compressor_running is False:
+            return HVACAction.IDLE
         if mode == HVACMode.DRY:
             return HVACAction.DRYING
         return HVACAction.COOLING

--- a/custom_components/frigidaire/compressor.py
+++ b/custom_components/frigidaire/compressor.py
@@ -1,0 +1,58 @@
+"""Temperature-based compressor state estimation."""
+
+from __future__ import annotations
+
+
+def estimate_compressor_running(
+    current: float | None,
+    target: float | None,
+    *,
+    hysteresis: float,
+    off_delay: float,
+    previous: bool,
+    satisfied_since: float | None,
+    now: float,
+) -> tuple[bool, float | None]:
+    """Return the next compressor estimate and satisfied-band timestamp."""
+    if current is None or target is None:
+        return previous, None
+
+    if current > target + hysteresis:
+        return True, None
+
+    if current <= target - hysteresis:
+        satisfied_since = now if satisfied_since is None else satisfied_since
+        if now - satisfied_since >= off_delay:
+            return False, satisfied_since
+        return previous, satisfied_since
+
+    return previous, None
+
+
+class CompressorEstimator:
+    """Maintain one compressor estimate across coordinator refreshes."""
+
+    def __init__(self, *, hysteresis: float, off_delay: float) -> None:
+        self.hysteresis = hysteresis
+        self.off_delay = off_delay
+        self.running = True
+        self.satisfied_since: float | None = None
+
+    def force_off(self) -> bool:
+        """Reset the estimate when operating state proves the compressor is off."""
+        self.running = False
+        self.satisfied_since = None
+        return self.running
+
+    def update(self, current: float | None, target: float | None, *, now: float) -> bool:
+        """Update and return the shared estimate."""
+        self.running, self.satisfied_since = estimate_compressor_running(
+            current,
+            target,
+            hysteresis=self.hysteresis,
+            off_delay=self.off_delay,
+            previous=self.running,
+            satisfied_since=self.satisfied_since,
+            now=now,
+        )
+        return self.running

--- a/custom_components/frigidaire/config_flow.py
+++ b/custom_components/frigidaire/config_flow.py
@@ -17,6 +17,11 @@ import frigidaire
 from .auth_store import AUTH_FILE, load_auth, save_auth
 from .const import (
     BINARY_SENSOR_OPTIONS,
+    CONF_COMPRESSOR_ESTIMATE,
+    CONF_COMPRESSOR_OFF_DELAY,
+    CONF_COOL_HYSTERESIS,
+    DEFAULT_COMPRESSOR_OFF_DELAY,
+    DEFAULT_COOL_HYSTERESIS,
     DOMAIN,
     SENSOR_OPTIONS,
     SWITCH_OPTIONS,
@@ -29,8 +34,25 @@ STEP_USER_DATA_SCHEMA = vol.Schema({"username": str, "password": str})
 ALL_OPTIONS = {**SWITCH_OPTIONS, **BINARY_SENSOR_OPTIONS, **SENSOR_OPTIONS}
 
 
-def _device_schema(current: dict) -> vol.Schema:
-    return vol.Schema({vol.Optional(key, default=current.get(key, False)): bool for key in ALL_OPTIONS})
+def _device_schema(current: dict, appliance: frigidaire.Appliance | None = None) -> vol.Schema:
+    fields: dict = {vol.Optional(key, default=current.get(key, False)): bool for key in ALL_OPTIONS}
+
+    if appliance is not None and appliance.destination == frigidaire.Destination.AIR_CONDITIONER:
+        fields[vol.Optional(CONF_COMPRESSOR_ESTIMATE, default=current.get(CONF_COMPRESSOR_ESTIMATE, False))] = bool
+        fields[
+            vol.Optional(
+                CONF_COOL_HYSTERESIS,
+                default=float(current.get(CONF_COOL_HYSTERESIS, DEFAULT_COOL_HYSTERESIS)),
+            )
+        ] = vol.All(vol.Coerce(float), vol.Range(min=0, max=10))
+        fields[
+            vol.Optional(
+                CONF_COMPRESSOR_OFF_DELAY,
+                default=int(current.get(CONF_COMPRESSOR_OFF_DELAY, DEFAULT_COMPRESSOR_OFF_DELAY)),
+            )
+        ] = vol.All(vol.Coerce(int), vol.Range(min=0, max=3600))
+
+    return vol.Schema(fields)
 
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> list[frigidaire.Appliance]:
@@ -74,7 +96,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._user_input: dict[str, Any] = {}
         self._appliances: list[frigidaire.Appliance] = []
         self._pending_appliances: list[frigidaire.Appliance] = []
-        self._options: dict[str, dict[str, bool]] = {}
+        self._options: dict[str, dict[str, Any]] = {}
 
     @staticmethod
     def async_get_options_flow(config_entry: config_entries.ConfigEntry) -> config_entries.OptionsFlow:
@@ -122,7 +144,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._pending_appliances.pop(0)
             return await self._async_next_device_step()
 
-        schema = _device_schema({})
+        schema = _device_schema({}, appliance)
         return self.async_show_form(
             step_id="device",
             data_schema=schema,
@@ -137,7 +159,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         self._entry_id = config_entry.entry_id
         self._appliances: list[frigidaire.Appliance] = []
         self._pending_appliances: list[frigidaire.Appliance] = []
-        self._options: dict[str, dict[str, bool]] = {}
+        self._options: dict[str, dict[str, Any]] = {}
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Load appliances then start per-device steps."""
@@ -162,7 +184,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             self._pending_appliances.pop(0)
             return await self._async_next_device_step()
 
-        schema = _device_schema(current)
+        schema = _device_schema(current, appliance)
         return self.async_show_form(
             step_id="device",
             data_schema=schema,

--- a/custom_components/frigidaire/const.py
+++ b/custom_components/frigidaire/const.py
@@ -12,7 +12,13 @@ SWITCH_OPTIONS: dict[str, str] = {
 
 # Keys must match diagnostic entity keys.
 CONF_CHECK_FILTER_SENSOR = "check_filter"
+CONF_COMPRESSOR_ESTIMATE = "compressor"
 CONF_FILTER_RUNTIME_SENSOR = "filter_runtime"
+
+DEFAULT_COOL_HYSTERESIS = 0.0
+DEFAULT_COMPRESSOR_OFF_DELAY = 300
+CONF_COOL_HYSTERESIS = "cool_hysteresis"
+CONF_COMPRESSOR_OFF_DELAY = "compressor_off_delay"
 
 BINARY_SENSOR_OPTIONS: dict[str, str] = {
     CONF_CHECK_FILTER_SENSOR: "Check Filter",

--- a/custom_components/frigidaire/coordinator.py
+++ b/custom_components/frigidaire/coordinator.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+import time
+from collections.abc import Mapping
 from datetime import timedelta
 from typing import Any
 
@@ -10,6 +12,15 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 import frigidaire
+
+from .compressor import CompressorEstimator
+from .const import (
+    CONF_COMPRESSOR_ESTIMATE,
+    CONF_COMPRESSOR_OFF_DELAY,
+    CONF_COOL_HYSTERESIS,
+    DEFAULT_COMPRESSOR_OFF_DELAY,
+    DEFAULT_COOL_HYSTERESIS,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,6 +41,13 @@ def _normalize(value: Any) -> Any:
     return value
 
 
+def _coerce_float(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return float(default)
+
+
 class FrigidaireApplianceCoordinator(DataUpdateCoordinator[dict]):
     """Polls a single Frigidaire appliance and shares its details with every entity."""
 
@@ -38,6 +56,7 @@ class FrigidaireApplianceCoordinator(DataUpdateCoordinator[dict]):
         hass: HomeAssistant,
         client: frigidaire.Frigidaire,
         appliance: frigidaire.Appliance,
+        options: Mapping[str, Any] | None = None,
     ) -> None:
         super().__init__(
             hass,
@@ -48,6 +67,27 @@ class FrigidaireApplianceCoordinator(DataUpdateCoordinator[dict]):
         self.client = client
         self.appliance = appliance
         self._failure_count = 0
+        options = options or {}
+        self._compressor_estimator = (
+            CompressorEstimator(
+                hysteresis=_coerce_float(options.get(CONF_COOL_HYSTERESIS), DEFAULT_COOL_HYSTERESIS),
+                off_delay=_coerce_float(options.get(CONF_COMPRESSOR_OFF_DELAY), DEFAULT_COMPRESSOR_OFF_DELAY),
+            )
+            if appliance.destination == frigidaire.Destination.AIR_CONDITIONER
+            and options.get(CONF_COMPRESSOR_ESTIMATE, False)
+            else None
+        )
+        self._compressor_running: bool | None = None
+
+    @property
+    def compressor_estimation_enabled(self) -> bool:
+        """Return whether temperature-based compressor estimation is enabled."""
+        return self._compressor_estimator is not None
+
+    @property
+    def compressor_running(self) -> bool | None:
+        """Return the shared temperature-based compressor estimate."""
+        return self._compressor_running
 
     @property
     def reported_fan_speed(self) -> str | None:
@@ -61,6 +101,38 @@ class FrigidaireApplianceCoordinator(DataUpdateCoordinator[dict]):
             frigidaire.FanSpeed.MEDIUM: "medium",
             frigidaire.FanSpeed.HIGH: "high",
         }.get(_normalize(raw), str(raw).lower())
+
+    def _update_compressor_estimate(self, details: dict) -> None:
+        """Update the opt-in estimate from one coordinator response."""
+        if self._compressor_estimator is None:
+            return
+
+        mode = _normalize(details.get(frigidaire.Detail.MODE))
+        appliance_state = _normalize(details.get(frigidaire.Detail.APPLIANCE_STATE))
+        if mode == frigidaire.Mode.OFF or (
+            appliance_state is not None and appliance_state != frigidaire.ApplianceState.RUNNING
+        ):
+            self._compressor_running = self._compressor_estimator.force_off()
+            return
+        if mode == frigidaire.Mode.FAN:
+            self._compressor_running = self._compressor_estimator.force_off()
+            return
+        if mode not in (frigidaire.Mode.COOL, frigidaire.Mode.ECO, frigidaire.Mode.AUTO, frigidaire.Mode.DRY):
+            self._compressor_running = None
+            return
+
+        unit = _normalize(details.get(frigidaire.Detail.TEMPERATURE_REPRESENTATION))
+        if unit == frigidaire.Unit.FAHRENHEIT:
+            current = details.get(frigidaire.Detail.AMBIENT_TEMPERATURE_F)
+            target = details.get(frigidaire.Detail.TARGET_TEMPERATURE_F)
+        elif unit == frigidaire.Unit.CELSIUS:
+            current = details.get(frigidaire.Detail.AMBIENT_TEMPERATURE_C)
+            target = details.get(frigidaire.Detail.TARGET_TEMPERATURE_C)
+        else:
+            self._compressor_running = None
+            return
+
+        self._compressor_running = self._compressor_estimator.update(current, target, now=time.monotonic())
 
     async def _async_update_data(self) -> dict:
         """Fetch the latest appliance details, backing off on repeated failures."""
@@ -77,4 +149,5 @@ class FrigidaireApplianceCoordinator(DataUpdateCoordinator[dict]):
         if self._failure_count:
             self._failure_count = 0
             self.update_interval = BASE_INTERVAL
+        self._update_compressor_estimate(details)
         return details

--- a/custom_components/frigidaire/strings.json
+++ b/custom_components/frigidaire/strings.json
@@ -15,11 +15,17 @@
           "display_light": "Display Light",
           "ui_lock": "Child Lock",
           "check_filter": "Check Filter",
-          "filter_runtime": "Filter runtime"
+          "filter_runtime": "Filter runtime",
+          "compressor": "Enable compressor estimate",
+          "cool_hysteresis": "Cooling hysteresis (degrees)",
+          "compressor_off_delay": "Compressor off delay (seconds)"
         },
         "data_description": {
           "check_filter": "Problem sensor that turns on when the filter state is CLEAN, CHANGE, or BUY. Use it to trigger filter-maintenance notifications.",
-          "filter_runtime": "Cumulative air-filter runtime reported by the appliance in native seconds. Home Assistant converts it to the configured display unit."
+          "filter_runtime": "Cumulative air-filter runtime reported by the appliance in native seconds. Home Assistant converts it to the configured display unit.",
+          "compressor": "Opt-in temperature-based estimate, not device telemetry. Adds a Compressor Estimate diagnostic sensor and refines hvac_action while enabled.",
+          "cool_hysteresis": "Temperature deadband around the setpoint used by the estimate. Zero disables the deadband.",
+          "compressor_off_delay": "How long the room must remain below the lower deadband boundary before the estimate changes to idle."
         }
       }
     },
@@ -43,11 +49,17 @@
           "display_light": "Display Light",
           "ui_lock": "Child Lock",
           "check_filter": "Check Filter",
-          "filter_runtime": "Filter runtime"
+          "filter_runtime": "Filter runtime",
+          "compressor": "Enable compressor estimate",
+          "cool_hysteresis": "Cooling hysteresis (degrees)",
+          "compressor_off_delay": "Compressor off delay (seconds)"
         },
         "data_description": {
           "check_filter": "Problem sensor that turns on when the filter state is CLEAN, CHANGE, or BUY. Use it to trigger filter-maintenance notifications.",
-          "filter_runtime": "Cumulative air-filter runtime reported by the appliance in native seconds. Home Assistant converts it to the configured display unit."
+          "filter_runtime": "Cumulative air-filter runtime reported by the appliance in native seconds. Home Assistant converts it to the configured display unit.",
+          "compressor": "Opt-in temperature-based estimate, not device telemetry. Adds a Compressor Estimate diagnostic sensor and refines hvac_action while enabled.",
+          "cool_hysteresis": "Temperature deadband around the setpoint used by the estimate. Zero disables the deadband.",
+          "compressor_off_delay": "How long the room must remain below the lower deadband boundary before the estimate changes to idle."
         }
       }
     }

--- a/custom_components/frigidaire/translations/en.json
+++ b/custom_components/frigidaire/translations/en.json
@@ -24,11 +24,17 @@
                     "display_light": "Display Light",
                     "ui_lock": "Child Lock",
                     "check_filter": "Check Filter",
-                    "filter_runtime": "Filter runtime"
+                    "filter_runtime": "Filter runtime",
+                    "compressor": "Enable compressor estimate",
+                    "cool_hysteresis": "Cooling hysteresis (degrees)",
+                    "compressor_off_delay": "Compressor off delay (seconds)"
                 },
                 "data_description": {
                     "check_filter": "Problem sensor that turns on when the filter state is CLEAN, CHANGE, or BUY. Use it to trigger filter-maintenance notifications.",
-                    "filter_runtime": "Cumulative air-filter runtime reported by the appliance in native seconds. Home Assistant converts it to the configured display unit."
+                    "filter_runtime": "Cumulative air-filter runtime reported by the appliance in native seconds. Home Assistant converts it to the configured display unit.",
+                    "compressor": "Opt-in temperature-based estimate, not device telemetry. Adds a Compressor Estimate diagnostic sensor and refines hvac_action while enabled.",
+                    "cool_hysteresis": "Temperature deadband around the setpoint used by the estimate. Zero disables the deadband.",
+                    "compressor_off_delay": "How long the room must remain below the lower deadband boundary before the estimate changes to idle."
                 }
             }
         }
@@ -43,11 +49,17 @@
                     "display_light": "Display Light",
                     "ui_lock": "Child Lock",
                     "check_filter": "Check Filter",
-                    "filter_runtime": "Filter runtime"
+                    "filter_runtime": "Filter runtime",
+                    "compressor": "Enable compressor estimate",
+                    "cool_hysteresis": "Cooling hysteresis (degrees)",
+                    "compressor_off_delay": "Compressor off delay (seconds)"
                 },
                 "data_description": {
                     "check_filter": "Problem sensor that turns on when the filter state is CLEAN, CHANGE, or BUY. Use it to trigger filter-maintenance notifications.",
-                    "filter_runtime": "Cumulative air-filter runtime reported by the appliance in native seconds. Home Assistant converts it to the configured display unit."
+                    "filter_runtime": "Cumulative air-filter runtime reported by the appliance in native seconds. Home Assistant converts it to the configured display unit.",
+                    "compressor": "Opt-in temperature-based estimate, not device telemetry. Adds a Compressor Estimate diagnostic sensor and refines hvac_action while enabled.",
+                    "cool_hysteresis": "Temperature deadband around the setpoint used by the estimate. Zero disables the deadband.",
+                    "compressor_off_delay": "How long the room must remain below the lower deadband boundary before the estimate changes to idle."
                 }
             }
         }

--- a/tests/test_compressor.py
+++ b/tests/test_compressor.py
@@ -1,0 +1,70 @@
+"""Tests for temperature-based compressor estimation."""
+
+from compressor import CompressorEstimator, estimate_compressor_running
+
+
+def estimate(
+    current,
+    target,
+    *,
+    hysteresis=0,
+    off_delay=180,
+    previous=True,
+    satisfied_since=None,
+    now=100,
+):
+    return estimate_compressor_running(
+        current,
+        target,
+        hysteresis=hysteresis,
+        off_delay=off_delay,
+        previous=previous,
+        satisfied_since=satisfied_since,
+        now=now,
+    )
+
+
+def test_above_target_reports_running_and_clears_timer():
+    assert estimate(72, 70, previous=False, satisfied_since=50) == (True, None)
+
+
+def test_satisfied_temperature_starts_off_delay():
+    assert estimate(70, 70, now=100) == (True, 100)
+
+
+def test_below_hysteresis_band_starts_off_delay():
+    assert estimate(68, 70, hysteresis=1, now=100) == (True, 100)
+
+
+def test_satisfied_temperature_stops_after_delay():
+    assert estimate(70, 70, satisfied_since=100, now=279) == (True, 100)
+    assert estimate(70, 70, satisfied_since=100, now=280) == (False, 100)
+
+
+def test_deadband_holds_previous_estimate_and_clears_timer():
+    assert estimate(70, 70, hysteresis=1, previous=False, satisfied_since=50) == (False, None)
+
+
+def test_missing_temperature_holds_previous_estimate():
+    assert estimate(None, 70, previous=False, satisfied_since=50) == (False, None)
+    assert estimate(72, None, previous=False, satisfied_since=50) == (False, None)
+
+
+def test_rising_temperature_restarts_compressor_immediately():
+    assert estimate(72, 70, previous=False, satisfied_since=50) == (True, None)
+
+
+def test_stateful_estimator_shares_transition_state():
+    estimator = CompressorEstimator(hysteresis=0, off_delay=180)
+
+    assert estimator.update(70, 70, now=100) is True
+    assert estimator.update(70, 70, now=280) is False
+    assert estimator.update(72, 70, now=281) is True
+
+
+def test_forced_off_clears_stale_running_state():
+    estimator = CompressorEstimator(hysteresis=0, off_delay=180)
+
+    assert estimator.update(72, 70, now=100) is True
+    estimator.force_off()
+    assert estimator.update(70, 70, now=101) is False


### PR DESCRIPTION
## Summary

- Add an optional, temperature-based Compressor Estimate diagnostic binary sensor for air conditioners.
- Refine the climate entity's `hvac_action` from cooling/drying to idle only while that per-device option is enabled and the estimate is false.
- Add per-device hysteresis and off-delay controls to avoid setpoint flapping and tune the estimate.
- Keep one coordinator-owned estimator shared by the climate and binary-sensor entities, using the existing coordinator response with no additional cloud polling.

## Follow-up to #138 review

This is the compressor-only follow-up requested during #138. It incorporates that review directly:

- **No default behavior change:** compressor estimation is disabled by default. The coordinator does not construct an estimator unless the option is enabled, and `hvac_action` follows the existing path while disabled or whenever an estimate is unavailable.
- **Helpers remain the preferred alternative for a standalone signal:** a Threshold helper plus a template binary sensor with `delay_off` can derive a separate entity from the exposed climate values. This integration option is for the case helpers cannot cover: changing the Frigidaire climate entity's own `hvac_action`.
- **Estimate, not telemetry:** the UI, entity name, and README consistently call this a Compressor Estimate. The Frigidaire API does not expose compressor state.
- **No fan-state inference:** `fanSpeedState` is not used because it can retain its last value while the appliance is off.
- **Fully opt-in and user-tunable:** the estimate, its binary sensor, and the `hvac_action` refinement are gated by the same per-AC option; hysteresis and off delay are configurable per appliance.
- **No extra API traffic:** estimation runs after the normal appliance coordinator refresh and is shared by all consumers.

## Estimation behavior

- Above `target + hysteresis`: estimate running immediately.
- At or below `target - hysteresis`: start/continue the off-delay timer, then estimate idle.
- Inside the deadband: retain the previous estimate.
- Off, fan-only, or an explicitly non-running appliance state: reset the estimate to off.
- Missing or unsupported inputs: leave `hvac_action` on its existing behavior rather than replacing it with an unknown action.

## Validation

- `pytest -q`: 34 passed
- `ruff check .`: passed
- `ruff format --check .`: passed
- Python compilation: passed
- Translation JSON parsing: passed
