### PR TITLE
Expose reported humidity, PM2.5, Wi-Fi signal and connectivity; derive hvac_action from modeState

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ A Home Assistant integration for Frigidaire WiFi-connected appliances, using the
 - ON/OFF timer control (30-minute increments, up to 24 hours)
 - Extra state attributes: `check_filter`, `reported_fan_speed`, and `active_alerts`;
 	the legacy `current_fan_speed` alias is retained for existing templates
+- `hvac_action` reflects the mode the appliance reports it is *actually* running, so an
+	Eco/Auto unit shows `cooling` vs `fan` as it cycles rather than the requested mode
 
 ### Dehumidifier
 
@@ -32,6 +34,23 @@ A Home Assistant integration for Frigidaire WiFi-connected appliances, using the
 - Target humidity control (35-85%, 5% steps)
 - Fan speed control via the `frigidaire.set_fan_mode` service: `low`, `medium`, `high`
 - Extra state attributes: `current_humidity`, `check_filter`, `fan_mode`, `bin_full`
+
+### Automatic Entities
+
+These are created automatically, but only for appliances that actually report the
+underlying value — no extra API polling is involved, since all of it arrives in the same
+cloud response the climate and dehumidifier entities already use.
+
+| Entity | Type | Description |
+|---|---|---|
+| Humidity | Humidity sensor | Room relative humidity, on appliances with a humidity sensor (including some ACs) |
+| PM2.5 | PM2.5 sensor | Particulate concentration in µg/m³, on appliances with an air-quality sensor |
+| Wi-Fi Signal | Signal strength sensor | RSSI in dBm plus a `link_quality` attribute. Diagnostic and **disabled by default** — enable it from the device page when troubleshooting |
+| Connectivity | Connectivity binary sensor | Whether the cloud can currently reach the appliance. Worth alerting on: a disconnected appliance keeps serving its last-known values, so every other entity looks healthy while its data silently goes stale |
+
+`pm10` is deliberately **not** exposed. On the appliances observed so far it alternates
+between a fixed placeholder value and a value identical to `pm25`, so it carries no
+information `pm25` does not already provide.
 
 ### Optional Entities
 

--- a/custom_components/frigidaire/binary_sensor.py
+++ b/custom_components/frigidaire/binary_sensor.py
@@ -30,16 +30,62 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     appliances: list[frigidaire.Appliance] = hass.data[DOMAIN][entry.entry_id]["appliances"]
     options: dict[str, dict[str, bool]] = entry.options
 
-    if not options:
-        return
-
+    # Connectivity is meaningful for every appliance and needs no per-device opt-in, so
+    # unlike the check-filter sensor it has no key in const.BINARY_SENSOR_OPTIONS — and it
+    # is created even when the entry has no options set at all.
     entities: list[BinarySensorEntity] = [
+        FrigidaireConnectivitySensor(coordinators[appliance.appliance_id], suggest_area(hass, appliance.nickname))
+        for appliance in appliances
+        if coordinators[appliance.appliance_id].connection_state is not None
+    ]
+
+    entities += [
         FrigidaireCheckFilterSensor(coordinators[appliance.appliance_id], suggest_area(hass, appliance.nickname))
         for appliance in appliances
         if options.get(appliance.appliance_id, {}).get(CONF_CHECK_FILTER_SENSOR, False)
     ]
 
     async_add_entities(entities)
+
+
+class FrigidaireConnectivitySensor(CoordinatorEntity[FrigidaireApplianceCoordinator], BinarySensorEntity):
+    """Binary sensor that is ON while the cloud reports the appliance as connected.
+
+    This distinguishes a genuinely offline appliance from one whose reported values have
+    simply gone stale — the rest of the integration cannot tell the difference, because a
+    disconnected appliance keeps returning its last-known reported properties.
+    """
+
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: FrigidaireApplianceCoordinator, suggested_area: str | None = None) -> None:
+        super().__init__(coordinator)
+        self._appliance = coordinator.appliance
+        self._attr_unique_id = f"{self._appliance.appliance_id}_connectivity"
+        self._attr_name = "Connectivity"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._appliance.appliance_id)},
+            name=self._appliance.nickname,
+            manufacturer="Frigidaire",
+            suggested_area=suggested_area,
+        )
+
+    @property
+    def available(self) -> bool:
+        # Deliberately not gated on super().available: when a poll fails, whether the
+        # appliance is reachable is exactly what the user wants to see, so report the last
+        # known connection state rather than going unavailable alongside everything else.
+        return self.coordinator.is_connected is not None
+
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+        state = self.coordinator.connection_state
+        return None if state is None else {"connection_state": state}
+
+    @property
+    def is_on(self) -> bool | None:
+        return self.coordinator.is_connected
 
 
 class FrigidaireCheckFilterSensor(CoordinatorEntity[FrigidaireApplianceCoordinator], BinarySensorEntity):

--- a/custom_components/frigidaire/climate.py
+++ b/custom_components/frigidaire/climate.py
@@ -71,6 +71,16 @@ FRIGIDAIRE_TO_HA_MODE = {
     frigidaire.Mode.DRY: HVACMode.DRY,
 }
 
+# Detail.MODE_STATE is the mode the appliance reports it is actually running, as opposed to
+# Detail.MODE which is what was requested. Only the concrete running modes are mapped:
+# anything else (ECO, AUTO, SMART) is a setting rather than an activity and falls through to
+# the mode-derived fallback in hvac_action.
+FRIGIDAIRE_MODE_STATE_TO_HA_ACTION = {
+    frigidaire.Mode.COOL: HVACAction.COOLING,
+    frigidaire.Mode.FAN: HVACAction.FAN,
+    frigidaire.Mode.DRY: HVACAction.DRYING,
+}
+
 FRIGIDAIRE_TO_HA_FAN_SPEED = {
     frigidaire.FanSpeed.AUTO: FAN_AUTO,
     frigidaire.FanSpeed.LOW: FAN_LOW,
@@ -279,8 +289,20 @@ class FrigidaireClimate(CoordinatorEntity[FrigidaireApplianceCoordinator], Clima
         appliance_state = _normalize_enum_value(self._details.get(frigidaire.Detail.APPLIANCE_STATE))
         if appliance_state != frigidaire.ApplianceState.RUNNING:
             return HVACAction.IDLE
-        # Running — report the action that matches the active mode rather than
-        # collapsing everything to COOLING.
+
+        # Prefer the appliance's reported modeState over the requested mode. In ECO/AUTO the
+        # requested mode says nothing about what the unit is doing right now, so this is the
+        # only way to distinguish actually cooling from just running the fan. Note that
+        # hvac_mode deliberately stays on the requested mode — that is the user's selection
+        # and must not flap as the compressor cycles.
+        mode_state = FRIGIDAIRE_MODE_STATE_TO_HA_ACTION.get(
+            _normalize_enum_value(self._details.get(frigidaire.Detail.MODE_STATE))
+        )
+        if mode_state is not None:
+            return mode_state
+
+        # No modeState reported — fall back to the action implied by the active mode rather
+        # than collapsing everything to COOLING.
         if mode == HVACMode.FAN_ONLY:
             return HVACAction.FAN
         if mode == HVACMode.DRY:

--- a/custom_components/frigidaire/coordinator.py
+++ b/custom_components/frigidaire/coordinator.py
@@ -22,6 +22,10 @@ _LOGGER = logging.getLogger(__name__)
 BASE_INTERVAL = timedelta(seconds=30)
 MAX_INTERVAL = timedelta(minutes=10)
 FAN_SPEED_STATE_KEY = "fanSpeedState"
+# Reported by the cloud as a sibling of "properties", so it never appears in the
+# properties.reported dict that becomes coordinator.data.
+CONNECTION_STATE_KEY = "connectionState"
+CONNECTED_STATE = "CONNECTED"
 
 
 def _normalize(value: Any) -> Any:
@@ -48,6 +52,23 @@ class FrigidaireApplianceCoordinator(DataUpdateCoordinator[dict]):
         self.client = client
         self.appliance = appliance
         self._failure_count = 0
+        self._connection_state: str | None = None
+
+    @property
+    def connection_state(self) -> str | None:
+        """Return the appliance's normalized cloud connection state, if reported."""
+        return self._connection_state
+
+    @property
+    def is_connected(self) -> bool | None:
+        """Return whether the appliance is currently reachable by the cloud.
+
+        None when the appliance does not report a connection state at all, so callers can
+        omit the entity rather than inventing a value.
+        """
+        if self._connection_state is None:
+            return None
+        return self._connection_state == CONNECTED_STATE
 
     @property
     def reported_fan_speed(self) -> str | None:
@@ -65,7 +86,9 @@ class FrigidaireApplianceCoordinator(DataUpdateCoordinator[dict]):
     async def _async_update_data(self) -> dict:
         """Fetch the latest appliance details, backing off on repeated failures."""
         try:
-            details = await self.hass.async_add_executor_job(self.client.get_appliance_details, self.appliance)
+            # Fetch the whole record rather than just properties.reported: connectionState
+            # is a sibling of "properties" and is dropped by get_appliance_details().
+            raw = await self.hass.async_add_executor_job(self.client.get_appliance_raw, self.appliance)
         except (frigidaire.FrigidaireException, ConnectionError) as err:
             self._failure_count += 1
             # 30s, 60s, 120s, 240s … capped at MAX_INTERVAL.
@@ -77,4 +100,8 @@ class FrigidaireApplianceCoordinator(DataUpdateCoordinator[dict]):
         if self._failure_count:
             self._failure_count = 0
             self.update_interval = BASE_INTERVAL
-        return details
+
+        self._connection_state = _normalize(raw.get(CONNECTION_STATE_KEY))
+        # coordinator.data stays exactly the properties.reported dict that every platform
+        # already indexes with frigidaire.Detail keys.
+        return raw.get("properties", {}).get("reported", {})

--- a/custom_components/frigidaire/diagnostics.py
+++ b/custom_components/frigidaire/diagnostics.py
@@ -46,3 +46,54 @@ def filter_runtime_seconds(value: Any) -> float | None:
     if not math.isfinite(seconds) or seconds < 0:
         return None
     return seconds
+
+
+def _finite_float(value: Any) -> float | None:
+    """Coerce to a finite float, or None if the value is missing or unparseable."""
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def humidity_percent(value: Any) -> float | None:
+    """Return a reported relative-humidity reading, or None if out of range."""
+    humidity = _finite_float(value)
+    if humidity is None or not 0 <= humidity <= 100:
+        return None
+    return humidity
+
+
+def particulate_matter(value: Any) -> float | None:
+    """Return a reported particulate concentration in ug/m3, or None if implausible."""
+    concentration = _finite_float(value)
+    if concentration is None or concentration < 0:
+        return None
+    return concentration
+
+
+def network_rssi(value: Any) -> float | None:
+    """Return the RSSI from a reported networkInterface mapping.
+
+    Appliances report signal strength nested under networkInterface rather than as a
+    top-level key, and omit the mapping entirely when they have never reported Wi-Fi
+    telemetry. A non-negative RSSI is rejected: real dBm readings here are always negative,
+    so 0 or above means the field is a placeholder rather than a measurement.
+    """
+    if not isinstance(value, Mapping):
+        return None
+    rssi = _finite_float(value.get("rssi"))
+    if rssi is None or rssi >= 0:
+        return None
+    return rssi
+
+
+def link_quality(value: Any) -> str | None:
+    """Return the normalized link-quality indicator from a networkInterface mapping."""
+    if not isinstance(value, Mapping):
+        return None
+    indicator = value.get("linkQualityIndicator")
+    if indicator is None:
+        return None
+    return str(indicator).upper()

--- a/custom_components/frigidaire/manifest.json
+++ b/custom_components/frigidaire/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/bm1549/home-assistant-frigidaire/issues",
   "requirements": [
-    "frigidaire==0.18.50"
+    "frigidaire==0.18.51"
   ],
-  "version": "0.1.38"
+  "version": "0.1.39"
 }

--- a/custom_components/frigidaire/sensor.py
+++ b/custom_components/frigidaire/sensor.py
@@ -2,13 +2,23 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfTemperature, UnitOfTime
+from homeassistant.const import (
+    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    UnitOfTemperature,
+    UnitOfTime,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
@@ -19,7 +29,14 @@ import frigidaire
 
 from .const import CONF_FILTER_RUNTIME_SENSOR, DOMAIN
 from .coordinator import FrigidaireApplianceCoordinator
-from .diagnostics import AIR_FILTER_LIFETIME_KEY, filter_runtime_seconds
+from .diagnostics import (
+    AIR_FILTER_LIFETIME_KEY,
+    filter_runtime_seconds,
+    humidity_percent,
+    link_quality,
+    network_rssi,
+    particulate_matter,
+)
 from .helpers import suggest_area
 
 
@@ -48,6 +65,70 @@ def _reports_temperature(details: dict) -> bool:
     )
 
 
+@dataclass(frozen=True)
+class SensorDescription:
+    """A sensor derived from a single reported detail.
+
+    value_fn does the parsing and validation, so a detail the appliance reports as a
+    placeholder or in an impossible range yields None and the sensor is never created.
+    """
+
+    key: str
+    name: str
+    detail: frigidaire.Detail
+    value_fn: Callable[[Any], float | None]
+    device_class: SensorDeviceClass
+    native_unit: str
+    state_class: SensorStateClass = SensorStateClass.MEASUREMENT
+    entity_category: EntityCategory | None = None
+    enabled_default: bool = True
+    attributes_fn: Callable[[Any], Mapping[str, Any] | None] | None = None
+    suggested_display_precision: int | None = None
+
+
+def _link_quality_attributes(raw: Any) -> Mapping[str, Any] | None:
+    indicator = link_quality(raw)
+    return None if indicator is None else {"link_quality": indicator}
+
+
+# Details the appliance already sends on every poll. Each entity is created only when its
+# value_fn returns a value, so appliances without the hardware stay clean.
+#
+# Deliberately absent: Detail.PM10. On a Telica portable AC it alternates between a fixed
+# placeholder (199) and a value identical to pm25, so it carries no information that pm25
+# does not already provide and would publish a bogus reading half the time.
+SENSOR_DESCRIPTIONS: tuple[SensorDescription, ...] = (
+    SensorDescription(
+        key="humidity",
+        name="Humidity",
+        detail=frigidaire.Detail.SENSOR_HUMIDITY,
+        value_fn=humidity_percent,
+        device_class=SensorDeviceClass.HUMIDITY,
+        native_unit=PERCENTAGE,
+    ),
+    SensorDescription(
+        key="pm25",
+        name="PM2.5",
+        detail=frigidaire.Detail.PM25,
+        value_fn=particulate_matter,
+        device_class=SensorDeviceClass.PM25,
+        native_unit=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    ),
+    SensorDescription(
+        key="wifi_signal",
+        name="Wi-Fi Signal",
+        detail=frigidaire.Detail.NETWORK_INTERFACE,
+        value_fn=network_rssi,
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        native_unit=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        # Useful when diagnosing a flaky appliance, noise the rest of the time.
+        enabled_default=False,
+        attributes_fn=_link_quality_attributes,
+    ),
+)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
     """Set up frigidaire sensor entities from a config entry."""
     coordinators: dict[str, FrigidaireApplianceCoordinator] = hass.data[DOMAIN][entry.entry_id]["coordinators"]
@@ -67,6 +148,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         FrigidaireFilterRuntimeSensor(coordinators[appliance.appliance_id], suggest_area(hass, appliance.nickname))
         for appliance in appliances
         if options.get(appliance.appliance_id, {}).get(CONF_FILTER_RUNTIME_SENSOR, False)
+    ]
+    # Reported-detail sensors apply to every appliance type. Creation is gated on the
+    # appliance actually reporting a usable value, which the primed coordinator data
+    # already tells us, so no extra API call is needed to detect capabilities.
+    entities += [
+        FrigidaireDetailSensor(
+            coordinators[appliance.appliance_id], description, suggest_area(hass, appliance.nickname)
+        )
+        for appliance in appliances
+        for description in SENSOR_DESCRIPTIONS
+        if description.value_fn((coordinators[appliance.appliance_id].data or {}).get(description.detail)) is not None
     ]
 
     async_add_entities(entities)
@@ -152,3 +244,51 @@ class FrigidaireFilterRuntimeSensor(CoordinatorEntity[FrigidaireApplianceCoordin
     @property
     def native_value(self) -> float | None:
         return self._runtime_seconds
+
+
+class FrigidaireDetailSensor(CoordinatorEntity[FrigidaireApplianceCoordinator], SensorEntity):
+    """A sensor backed by a single reported detail, described by SENSOR_DESCRIPTIONS."""
+
+    def __init__(
+        self,
+        coordinator: FrigidaireApplianceCoordinator,
+        description: SensorDescription,
+        suggested_area: str | None = None,
+    ) -> None:
+        super().__init__(coordinator)
+        self._appliance = coordinator.appliance
+        self._desc = description
+        self._attr_unique_id = f"{self._appliance.appliance_id}_{description.key}"
+        self._attr_name = description.name
+        self._attr_device_class = description.device_class
+        self._attr_native_unit_of_measurement = description.native_unit
+        self._attr_state_class = description.state_class
+        self._attr_entity_category = description.entity_category
+        self._attr_entity_registry_enabled_default = description.enabled_default
+        self._attr_suggested_display_precision = description.suggested_display_precision
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._appliance.appliance_id)},
+            name=self._appliance.nickname,
+            manufacturer="Frigidaire",
+            suggested_area=suggested_area,
+        )
+
+    @property
+    def _raw(self) -> Any:
+        return (self.coordinator.data or {}).get(self._desc.detail)
+
+    @property
+    def available(self) -> bool:
+        # An appliance can stop reporting a detail (or report a placeholder) while staying
+        # online, so fall back to unavailable rather than holding a stale reading.
+        return super().available and self._desc.value_fn(self._raw) is not None
+
+    @property
+    def native_value(self) -> float | None:
+        return self._desc.value_fn(self._raw)
+
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+        if self._desc.attributes_fn is None:
+            return None
+        return self._desc.attributes_fn(self._raw)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -6,8 +6,12 @@ import pytest
 from diagnostics import (
     filter_needs_attention,
     filter_runtime_seconds,
+    humidity_percent,
+    link_quality,
+    network_rssi,
     normalize_alerts,
     normalize_filter_state,
+    particulate_matter,
 )
 
 
@@ -57,3 +61,74 @@ def test_normalize_alerts(alerts, expected):
 )
 def test_filter_runtime_seconds(seconds, expected):
     assert filter_runtime_seconds(seconds) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (86, 86),
+        ("48.5", 48.5),
+        (0, 0),
+        (100, 100),
+        (None, None),
+        ("invalid", None),
+        (-1, None),
+        (101, None),
+        (math.inf, None),
+        (math.nan, None),
+    ],
+)
+def test_humidity_percent(value, expected):
+    assert humidity_percent(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (4, 4),
+        ("12", 12),
+        (0, 0),
+        (None, None),
+        ("invalid", None),
+        (-1, None),
+        (math.inf, None),
+        (math.nan, None),
+    ],
+)
+def test_particulate_matter(value, expected):
+    assert particulate_matter(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ({"linkQualityIndicator": "EXCELLENT", "rssi": -41}, -41),
+        ({"rssi": "-67"}, -67),
+        # Positive dBm is not a real reading, so treat it as a placeholder.
+        ({"rssi": 41}, None),
+        ({"rssi": 0}, None),
+        ({"linkQualityIndicator": "EXCELLENT"}, None),
+        ({}, None),
+        (None, None),
+        # Appliances that report no Wi-Fi telemetry can send a scalar or a list here.
+        ("EXCELLENT", None),
+        ([], None),
+    ],
+)
+def test_network_rssi(value, expected):
+    assert network_rssi(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ({"linkQualityIndicator": "EXCELLENT", "rssi": -41}, "EXCELLENT"),
+        ({"linkQualityIndicator": "poor"}, "POOR"),
+        ({"rssi": -41}, None),
+        ({}, None),
+        (None, None),
+        ("EXCELLENT", None),
+    ],
+)
+def test_link_quality(value, expected):
+    assert link_quality(value) == expected


### PR DESCRIPTION
## Summary

Pull more data that's in the API response and expose it to HA.

On my portable AC the integration created exactly three entities (a climate entity and two timer numbers) while the appliance was also reporting room humidity, a PM2.5 reading, Wi-Fi signal quality, its actual running mode, and its cloud connection state.

### New sensors

Each is created **only when the appliance actually reports a usable value**, generalising the existing `_reports_temperature()` capability check, so appliances without the hardware are completely unaffected.

| Entity | Source | Notes |
|---|---|---|
| Humidity | `sensorHumidity` | Not DH-only — some ACs report room humidity |
| PM2.5 | `pm25` | µg/m³ |
| Wi-Fi Signal | `networkInterface.rssi` | dBm, `link_quality` attribute, diagnostic, **disabled by default** |
| Connectivity | `connectionState` | Diagnostic, no opt-in |

The connectivity sensor is the one thing the integration previously could not tell a user at all: a disconnected appliance keeps serving its last-known reported properties, so every other entity looks perfectly healthy while its data silently goes stale. It intentionally does **not** gate on `super().available` — when a poll fails, whether the appliance is reachable is exactly what you want to see.

### `pm10` deliberately not exposed

Over five consecutive polls `pm10` read `199, 199, 3, 1, 1` while `pm25` read
`2, 2, 3, 1, 1`. When it isn't `199` it is *identical* to `pm25`, so it carries no information `pm25` doesn't already provide and would publish a placeholder much of the time.

### `hvac_action` now prefers `modeState`

`hvac_action` derived from the *requested* mode, which in Eco/Auto says nothing about what the unit is doing right now. It now prefers the reported `modeState`, falling back to the old behaviour when absent.

`hvac_mode` deliberately stays on the requested mode — that is the user's selection and must not flap as the compressor cycles.

## Testing

Verified against a real Telica portable AC (`custom_components` + a patched library in-place), not just unit tests:

- `pytest`: 58 passed (47 before + 11 new); `ruff check` / `ruff format --check` clean
- **Humidity accuracy**: the appliance reported `86.0 %` against an independent Zigbee sensor in the same room reading `84.8 %` — a 1.2 pp delta.
- **Wi-Fi Signal**: registered `disabled_by=integration` as intended; enabling it gave `-49.0 dBm` with `link_quality: VERY_GOOD`.
- **Connectivity**: `on`, `connection_state: CONNECTED`.
- **`hvac_action`**: with `modeState: fanOnly` → `fan`; commanding `hvac_mode: cool` moved the appliance to `modeState: cool` and `hvac_action` followed to `cooling`; restoring `fan_only` returned it to `fan`.
- No errors from `custom_components.frigidaire` in the log.

### What I could not test

There is no dehumidifier on my account, so the DH paths are reasoned about by inspection only. The humidity sensor is presence-gated and `humidifier.py` is untouched, but the DH side would benefit from a second pair of eyes.

## Dependency

Requires `frigidaire` 0.18.51 for `Detail.MODE_STATE`, `Detail.PM25` and
`get_appliance_raw()` — the last of which is what makes `connectionState` reachable at all. That is bm1549/frigidaire#76, so **this wants to land after that ships to PyPI**.
